### PR TITLE
docs: RCE Profile v0.1 — replay-constrained episode normative schema

### DIFF
--- a/RCE_PROFILE.md
+++ b/RCE_PROFILE.md
@@ -33,7 +33,7 @@ All hash fields in this profile use the prefixed format `sha256:<64-char-lowerca
 
 **Do not create two Episode truths.** AgentMesh owns episode identity and provenance. Assay owns replay contracts, receipts, and proof compilation.
 
-### 0.2 Relationship to Founding Laws
+### 0.3 Relationship to Founding Laws
 
 | Law | Statement | RCE Relevance |
 |-----|-----------|---------------|

--- a/RCE_PROFILE.md
+++ b/RCE_PROFILE.md
@@ -1,5 +1,9 @@
 # Assay Protocol — Replay-Constrained Episode (RCE) Profile v0.1
 
+> Canonical source: `Haserjian/assay-protocol`.
+>
+> The normative home for this profile is `assay-protocol/RCE_PROFILE.md`. This copy remains in Assay as an implementation-local mirror for verifier and fixture work and MUST NOT diverge intentionally.
+
 **Status:** Draft companion to SPEC.md
 **Version:** 0.1.0
 **Date:** 2026-04-06

--- a/RCE_PROFILE.md
+++ b/RCE_PROFILE.md
@@ -23,7 +23,11 @@ This is a companion to [SPEC.md](./SPEC.md) and [CONSTITUTIONAL_RECEIPT_STANDARD
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-### 0.1 Pinned Invariants
+### 0.1 Hash Encoding
+
+All hash fields in this profile use the prefixed format `sha256:<64-char-lowercase-hex>`. This applies to all cross-verifiable and local-attestation hashes in receipts, contracts, and dispute payloads. Verifiers MUST compare hashes as exact string equality on the prefixed form.
+
+### 0.2 Pinned Invariants
 
 **Episodes are the truth-bearing work unit. Proof packs are the compiled evidence artifact.**
 
@@ -144,7 +148,7 @@ Every hash field in the RCE receipt set MUST be recomputable by a second impleme
 | `env_fingerprint_hash` | `{provider, model_id, tool_versions, container_digest}` | JCS → SHA-256 | JCS key sort | §2.3 |
 | `inputs_hash` | `episode_contract["inputs"]` (full array) | JCS → SHA-256 | Array order from contract | `episode_open` |
 | `script_hash` | `episode_contract["replay_script"]` (full object) | JCS → SHA-256 | JCS key sort | `episode_open`, `replay_result` |
-| `outputs_hash` | Array of `{"step_id", "output_hash"}` per `EMIT_OUTPUT` step | JCS → SHA-256 | Lexicographic by `step_id` | `episode_close` |
+| `outputs_hash` | Array of `{"step_id", "output_hash"}` per `EMIT_OUTPUT` step with `step_status: PASS` (excludes SKIPPED/FAIL) | JCS → SHA-256 | Lexicographic by `step_id` | `episode_close` |
 | `output_hash` (step) | Step output JSON (opcode-specific; see §3.3) | JCS → SHA-256 | Single object | `episode_step` |
 | `input_hashes` (step) | `output_hash` values from direct dependencies | None (pre-computed) | `depends_on` order | `episode_step` |
 
@@ -206,7 +210,7 @@ Every `rce.episode_step/v0` receipt MUST include `step_status` in its payload.
 - `EMIT_OUTPUT` steps with a schema violation MUST include `schema_validation_error: "<message>"`.
 - Missing replay artifacts at verification time are `INTEGRITY_FAIL` (§6.2), not step-level `FAIL`.
 
-**Step output hashes by opcode:**
+**Step output hashes by opcode and status:**
 
 | Opcode | `output_hash` input |
 |--------|-------------------|
@@ -214,6 +218,9 @@ Every `rce.episode_step/v0` receipt MUST include `step_status` in its payload.
 | `APPLY_TRANSFORM` | The transform's structured output |
 | `ASSERT_HASH` | `{"assertion_passed": true}` or `{"assertion_passed": false}` |
 | `EMIT_OUTPUT` | The emitted claim object |
+| *(any, when `step_status: SKIPPED`)* | `null` — field MUST be present with value `null`. No output was produced. |
+
+**SKIPPED step receipts:** `output_hash` MUST be `null`. `input_hashes` MUST be `[]`. `output_size_bytes` and `duration_ms` MUST be `0`. These steps are excluded from `outputs_hash` computation (§2.4) and from Phase 4 replay comparison (§6.2).
 
 ### 3.5 Step Failure Propagation
 
@@ -288,7 +295,7 @@ Emitted once per step execution.
 | `opcode` | string | One of: `LOAD_INPUT`, `ASSERT_HASH`, `APPLY_TRANSFORM`, `EMIT_OUTPUT` |
 | `step_status` | string | `PASS`, `FAIL`, or `SKIPPED` (§3.4) |
 | `input_hashes` | array[string] | Dependency output hashes in `depends_on` order (§2.4) |
-| `output_hash` | string | SHA-256 of JCS(step_output) (§2.4) |
+| `output_hash` | string\|null | SHA-256 of JCS(step_output) (§2.4). `null` when `step_status` is `SKIPPED`. |
 | `output_size_bytes` | integer | Size of step output |
 | `duration_ms` | integer | Step execution duration |
 | `comparator_tier` | string | Tier applied to this step |
@@ -330,7 +337,7 @@ Emitted by a replay verifier (not the original executor). This receipt makes RCE
 | `original_pack_root_sha256` | string | Evidence identity of original pack |
 | `verdict` | string | `MATCH`, `DIVERGE`, or `INTEGRITY_FAIL` (§6) |
 | `receipt_integrity` | string | `PASS` or `FAIL` |
-| `claim_check` | string | `PASS` or `FAIL` |
+| `claim_check` | string\|null | `PASS`, `FAIL`, or `null`. MUST be `null` when `verdict` is `INTEGRITY_FAIL` (comparison was not reached). |
 | `replay_basis` | string | `"recorded_trace"` in v0 |
 | `comparator_tier` | string | `"A"` in v0 |
 | `script_hash` | string | SHA-256 of JCS(replay_script) |
@@ -371,7 +378,7 @@ RCE verdicts map onto the existing Assay two-axis contract (`receipt_integrity` 
 |---------|:-------------------:|:-------------:|:---------:|:-------------:|
 | `MATCH` | PASS | PASS | 0 | **PASS** |
 | `DIVERGE` | PASS | FAIL | 1 | **HONEST FAIL** |
-| `INTEGRITY_FAIL` | FAIL | — | 2 | **TAMPERED** |
+| `INTEGRITY_FAIL` | FAIL | `null` | 2 | **TAMPERED** |
 
 ### 6.1 Verdict Precedence
 
@@ -383,10 +390,10 @@ A conforming verifier MUST execute these phases in order. No phase begins until 
 
 | Phase | Action | Failure Verdict |
 |:-----:|--------|-----------------|
-| **1** | **Script validation.** Parse Episode Contract. Validate: unique step_ids, resolved depends_on, no cycles, at least one terminal EMIT_OUTPUT. | `INTEGRITY_FAIL` |
+| **1** | **Script validation.** Parse Episode Contract. Validate: all `step_id` values unique (the verifier MUST enforce uniqueness; JSON Schema `uniqueItems` does not cover object-field uniqueness), all `depends_on` references resolve to declared step_ids, no cycles, at least one terminal EMIT_OUTPUT. | `INTEGRITY_FAIL` |
 | **2** | **Pack integrity.** Standard Assay verification: file hashes, receipt chain, signature checks, attestation block. | `INTEGRITY_FAIL` |
-| **3** | **Completeness.** Verify artifacts present: Episode Contract, all input artifacts, one recorded trace per step. Verify receipts: one `episode_open`, one `episode_step` per step, one `episode_close`. Recompute and verify: `episode_spec_hash` (§2.1), `env_fingerprint_hash` (§2.3), `inputs_hash`, `script_hash` (§2.4), `outputs_hash` (§2.4). | `INTEGRITY_FAIL` |
-| **4** | **Replay comparison.** For each step in DAG order: verify `input_hashes` against dependency `output_hash` values in `depends_on` order; recompute step output from replay artifact; compare against receipt `output_hash` under declared comparator tier. Collect all divergences. | `DIVERGE` or `MATCH` |
+| **3** | **Completeness.** Verify artifacts present: Episode Contract, all input artifacts, one recorded trace per non-SKIPPED step. Verify receipts: one `episode_open`, one `episode_step` per script step (including SKIPPED), one `episode_close`. Recompute from the Episode Contract: `episode_spec_hash` (§2.1), `env_fingerprint_hash` (§2.3), `inputs_hash`, `script_hash` (§2.4). Recompute `outputs_hash` (§2.4) from `episode_step` receipt `output_hash` values for EMIT_OUTPUT steps — using **receipt payload values**, not replay artifacts. Reject if any recomputed hash does not match. | `INTEGRITY_FAIL` |
+| **4** | **Replay comparison.** For each step in DAG order: skip steps with `step_status: SKIPPED` (no replay artifact exists). For non-SKIPPED steps: verify `input_hashes` against dependency `output_hash` values in `depends_on` order; recompute step output hash from the recorded trace artifact; compare against the step receipt's `output_hash` under the step's declared comparator tier (use `replay_policy.comparator_tiers_by_step[step_id]` if present, otherwise `replay_policy.comparator_tier`). Collect all divergences per §5.5 collection policy. | `DIVERGE` or `MATCH` |
 
 **Consequence:** Two conforming verifiers given the same pack, contract, and traces MUST produce the same verdict.
 

--- a/RCE_PROFILE.md
+++ b/RCE_PROFILE.md
@@ -1,0 +1,461 @@
+# Assay Protocol — Replay-Constrained Episode (RCE) Profile v0.1
+
+**Status:** Draft companion to SPEC.md
+**Version:** 0.1.0
+**Date:** 2026-04-06
+**Author:** Tim B. Haserjian
+**Scope:** Replay verification of agent work units (episodes)
+**Grounded in:** Assay Proof Pack Contract, Constitutional Receipt Standard (CRS) v0.1, RFC 8785 (JCS), RFC 8032 (Ed25519)
+
+---
+
+## Abstract
+
+This profile defines a **Replay-Constrained Episode (RCE)**: a verifiable work unit whose correctness is defined by replay against recorded evidence. An episode compiles into an Assay Proof Pack and produces receipts that conform to the Constitutional Receipt Standard.
+
+This is a companion to [SPEC.md](./SPEC.md) and [CONSTITUTIONAL_RECEIPT_STANDARD_v0.1.md](./CONSTITUTIONAL_RECEIPT_STANDARD_v0.1.md), not a replacement. Implementers should read both.
+
+**Scope:** RCE defines *what a replayable work unit is*. Profiles (e.g., Tool Safety) define *what actions within an episode must be proven*.
+
+---
+
+## 0. Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+### 0.1 Pinned Invariants
+
+**Episodes are the truth-bearing work unit. Proof packs are the compiled evidence artifact.**
+
+**Do not create two Episode truths.** AgentMesh owns episode identity and provenance. Assay owns replay contracts, receipts, and proof compilation.
+
+### 0.2 Relationship to Founding Laws
+
+| Law | Statement | RCE Relevance |
+|-----|-----------|---------------|
+| **2. Truth = Replay** | Every decision is deterministically replayable | RCE operationalizes this law as a protocol |
+| **3. No Action Without Receipt** | All consequential acts emit receipts | Episode steps emit receipts into proof packs |
+| **4. Tri-Temporal Integrity** | valid_time ≤ observed_at ≤ recorded_at | Receipt timestamps in episode steps are proofs |
+
+---
+
+## 1. Terminology [Normative]
+
+| Term | Definition |
+|------|-----------|
+| **Episode** | A bounded unit of agent work with declared inputs, a typed step DAG, and structured outputs. |
+| **Episode Contract** | The replay-relevant specification of an episode: inputs, script, policy, and identity-bearing environment. |
+| **Replay-Normative View** | The subset of an Episode Contract that determines replay identity. Excludes descriptive metadata. |
+| **ReplayScript** | A typed DAG of opcodes that defines the episode's execution steps. |
+| **Recorded Trace** | The JSON output artifacts captured during original episode execution. Used as the reference for replay comparison. |
+| **Replay Verifier** | An independent implementation that replays an episode's recorded traces against its receipts and emits a verdict. |
+| **Comparator Tier** | The comparison method used to determine whether replay outputs match. v0.1 supports Tier A only. |
+| **Dispute Payload** | Structured evidence attached to a `DIVERGE` verdict identifying which steps diverged and how. |
+| **Proof Pack** | An Assay evidence unit containing receipts, manifest, verification report, and signature. Episodes compile into proof packs. |
+
+---
+
+## 2. Identity Model [Normative]
+
+An RCE system distinguishes three identities that MUST NOT be conflated:
+
+| Identity | Owner | Semantics | Mutable? |
+|----------|-------|-----------|----------|
+| `episode_id` | AgentMesh | Operational runtime handle. AgentMesh-native time-sortable identifier (`ep_` prefix + 48-bit ms timestamp + 48-bit random). Not a standard ULID — do not assume ULID semantics. | No |
+| `episode_spec_hash` | Assay (RCE module) | SHA-256 of JCS-canonicalized replay-normative view (§2.1). The replay identity: what was supposed to run. Excludes descriptive metadata. | No |
+| `pack_root_sha256` | Assay (proof pack) | SHA-256 of the compiled pack manifest attestation block. The evidence identity: what was actually produced. | No |
+
+**Rationale:** `episode_id` identifies *the thing that ran*. `episode_spec_hash` identifies *the thing that was supposed to run*. `pack_root_sha256` identifies *the artifact compiled from the run*.
+
+### 2.1 Replay-Normative View
+
+`episode_spec_hash` is computed over the **replay-normative subset** of the Episode Contract, excluding descriptive metadata that MUST NOT affect replay identity.
+
+The replay-normative view includes exactly these top-level keys:
+
+- `inputs`
+- `replay_script`
+- `replay_policy`
+- `environment` (identity-bearing subset only; see §2.3)
+
+The replay-normative view **excludes**:
+
+- `schema_version` (envelope, not identity)
+- `episode_id` (runtime handle, not specification)
+- `objective` (descriptive — see §2.2)
+- `environment.env_fingerprint_hash` (derived cross-check, not a direct identity input)
+- `environment.model_version_hint` (advisory, not identity)
+- `environment.system_fingerprint` (runtime audit field, not identity)
+
+```
+replay_normative_environment = {
+  "provider":         environment["provider"],
+  "model_id":         environment["model_id"],
+  "tool_versions":    environment["tool_versions"],
+  "container_digest": environment["container_digest"]
+}
+
+replay_normative_view = {
+  "inputs":         episode_contract["inputs"],
+  "replay_script":  episode_contract["replay_script"],
+  "replay_policy":  episode_contract["replay_policy"],
+  "environment":    replay_normative_environment
+}
+
+episode_spec_hash = SHA256( JCS( replay_normative_view ) )
+```
+
+JCS canonicalization per [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785). This matches the existing Assay canonicalization regime (`canon_version: "jcs-rfc8785"`).
+
+**Consequence:** Two Episode Contracts with different `objective` text but identical inputs, script, policy, and identity-bearing environment fields produce the **same** `episode_spec_hash`.
+
+### 2.2 Descriptive Fields
+
+`objective` is descriptive. It MUST NOT be used as a dispatch input by the replay verifier and MUST NOT affect `episode_spec_hash`. It is carried in the Episode Contract and in `rce.episode_open/v0` receipts for human context and audit provenance only.
+
+### 2.3 Environment Fingerprint
+
+`env_fingerprint_hash` is a **derived digest** of the identity-bearing subset of `environment`, carried as a verifier cross-check.
+
+```
+env_fingerprint_input = {
+  "provider":         environment["provider"],
+  "model_id":         environment["model_id"],
+  "tool_versions":    environment["tool_versions"],
+  "container_digest": environment["container_digest"]
+}
+
+env_fingerprint_hash = SHA256( JCS( env_fingerprint_input ) )
+```
+
+A verifier MUST recompute `env_fingerprint_hash` from these fields and reject the contract if the declared value does not match.
+
+**Excluded from fingerprint:** `env_fingerprint_hash` itself (circular), `model_version_hint` (advisory), `system_fingerprint` (runtime audit).
+
+### 2.4 Derived Hash Fields
+
+Every hash field in the RCE receipt set MUST be recomputable by a second implementation, or explicitly classified as a local attestation.
+
+#### Cross-Verifiable Hashes
+
+| Field | Input | Canonicalization | Ordering | Where |
+|-------|-------|-----------------|----------|-------|
+| `episode_spec_hash` | `{inputs, replay_script, replay_policy, replay_normative_environment}` | JCS → SHA-256 | JCS key sort | §2.1 |
+| `env_fingerprint_hash` | `{provider, model_id, tool_versions, container_digest}` | JCS → SHA-256 | JCS key sort | §2.3 |
+| `inputs_hash` | `episode_contract["inputs"]` (full array) | JCS → SHA-256 | Array order from contract | `episode_open` |
+| `script_hash` | `episode_contract["replay_script"]` (full object) | JCS → SHA-256 | JCS key sort | `episode_open`, `replay_result` |
+| `outputs_hash` | Array of `{"step_id", "output_hash"}` per `EMIT_OUTPUT` step | JCS → SHA-256 | Lexicographic by `step_id` | `episode_close` |
+| `output_hash` (step) | Step output JSON (opcode-specific; see §3.3) | JCS → SHA-256 | Single object | `episode_step` |
+| `input_hashes` (step) | `output_hash` values from direct dependencies | None (pre-computed) | `depends_on` order | `episode_step` |
+
+#### Local Attestation Hashes
+
+These are carried for audit provenance. Downstream consumers do NOT recompute them.
+
+| Field | Semantics | Where | Why Not Cross-Verifiable |
+|-------|-----------|-------|--------------------------|
+| `config_hash` | Opaque digest of transform configuration | Step `params` | Source config not in receipts/traces |
+| `verifier_env_hash` | Verifier's own environment digest (same pattern as §2.3) | `replay_result` | Full verifier env object not exposed in v0 |
+
+#### Dispute Payload Hashes
+
+`expected_output_hash` and `observed_output_hash` (§5.5) use the same derivation as step-level `output_hash`.
+
+#### Verification Rule
+
+A verifier MUST recompute `inputs_hash` and `script_hash` from the Episode Contract and reject the pack if the `episode_open` receipt values do not match. A verifier MUST recompute `outputs_hash` from step receipts and reject the pack if the `episode_close` receipt value does not match. Step-level hashes are verified transitively during replay comparison (§6.2 Phase 4). `config_hash` and `verifier_env_hash` are not replay-identity checks in v0.
+
+---
+
+## 3. ReplayScript v0 [Normative]
+
+v0 is deliberately minimal. Opcodes are typed steps in a DAG.
+
+### 3.1 Opcode Set
+
+| Opcode | Semantics | Required Params | Produces |
+|--------|-----------|-----------------|----------|
+| `LOAD_INPUT` | Load an immutable input by reference. Verifier checks `ref` resolves and hash matches. | `ref` | Loaded data |
+| `ASSERT_HASH` | **Verifier assertion, not an execution transform.** Checks that a prior step's output matches an expected SHA-256 digest. See §3.3. | `target`, `expected_hash` | Boolean pass/fail |
+| `APPLY_TRANSFORM` | Apply a named transform to upstream step outputs. v0: recorded-trace only. | `transform`, provider/model/config metadata | Structured output |
+| `EMIT_OUTPUT` | Emit a final structured claim into episode outputs. Verifier checks schema validity. See §3.3. | `claim_type`, `output_ref` | Claim |
+
+### 3.2 Deferred Opcodes
+
+Explicitly deferred to v0.1+: `LLM_CALL` (live execution), `TOOL_CALL` (live execution), `COMPARE_SEMANTIC` (Tier C), `ANCHOR` (witness layer), `FETCH` (network I/O during replay).
+
+### 3.3 Step DAG Rules
+
+- Each step MUST declare `depends_on` (array of step_ids, may be empty for root steps).
+- Cycles are forbidden. A verifier MUST reject a script containing cycles.
+- Steps with no downstream dependents are terminal. At least one terminal step MUST be `EMIT_OUTPUT`.
+
+### 3.4 Step Status Model
+
+Every `rce.episode_step/v0` receipt MUST include `step_status` in its payload.
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | Step completed successfully. |
+| `FAIL` | Step completed but produced a negative result during original execution. |
+| `SKIPPED` | Step was not executed because a dependency had `step_status: FAIL`. |
+
+**Opcode-specific fields:**
+
+- `ASSERT_HASH` steps MUST include `assertion_passed: true | false`.
+- `EMIT_OUTPUT` steps with a schema violation MUST include `schema_validation_error: "<message>"`.
+- Missing replay artifacts at verification time are `INTEGRITY_FAIL` (§6.2), not step-level `FAIL`.
+
+**Step output hashes by opcode:**
+
+| Opcode | `output_hash` input |
+|--------|-------------------|
+| `LOAD_INPUT` | The loaded input data |
+| `APPLY_TRANSFORM` | The transform's structured output |
+| `ASSERT_HASH` | `{"assertion_passed": true}` or `{"assertion_passed": false}` |
+| `EMIT_OUTPUT` | The emitted claim object |
+
+### 3.5 Step Failure Propagation
+
+A step with `step_status: FAIL` blocks all direct and transitive dependents. Blocked steps MUST be emitted as receipts with `step_status: SKIPPED`. Every step in the script produces exactly one step receipt.
+
+If any step has `step_status: FAIL` or `SKIPPED`, the `episode_close` receipt MUST set `all_steps_passed: false`. This causes pack-level `claim_check: FAIL` with `receipt_integrity: PASS` (exit 1 / HONEST FAIL).
+
+**`claim_check` is a pack-level and episode-level verdict axis — it does NOT appear on individual step receipts.**
+
+---
+
+## 4. Comparator Tiers [Normative]
+
+| Tier | Name | Method | v0.1 Support |
+|------|------|--------|:------------:|
+| A | Canonical cryptographic match | `SHA256(JCS(output_a)) == SHA256(JCS(output_b))` — JCS absorbs whitespace/key-ordering. | **YES — sole tier** |
+| C | Semantic equivalence | Bounded judge + quorum | Deferred |
+| D | Predictive falsification | Future evidence verification | Deferred |
+
+**Why no Tier B:** Tier A already canonicalizes via JCS before hashing, making a separate "canonical-JSON match without hashing" tier operationally indistinguishable. A future version may add Tier B for non-JSON outputs.
+
+### 4.1 Replay Basis
+
+| Value | Meaning | v0.1 |
+|-------|---------|:----:|
+| `recorded_trace` | Compare against recorded step outputs. No live execution. | **YES** |
+| `live_reexecution` | Re-execute steps against live providers. | Deferred |
+
+**This distinction is a replay mode, not an implementation detail.** `replay_basis` and `comparator_tier` are independent axes. A claim verified under `recorded_trace` MUST NOT be presented as equivalent to `live_reexecution`.
+
+---
+
+## 5. Receipt Types [Normative]
+
+All four receipt types emit into the existing `receipt_pack.jsonl` stream and conform to the CRS v0.1 envelope (§3 of [CONSTITUTIONAL_RECEIPT_STANDARD_v0.1.md](./CONSTITUTIONAL_RECEIPT_STANDARD_v0.1.md)).
+
+**Two version strata — do not conflate:**
+
+| Stratum | Field | Example | Semantics |
+|---------|-------|---------|-----------|
+| Protocol type | `receipt_type` | `rce.episode_open/v0` | RCE protocol version |
+| Container | `schema_version` | `"3.0"` | Assay receipt pack envelope version |
+
+### 5.1 `rce.episode_open/v0`
+
+Emitted once at episode start. Binds the runtime handle to the replay contract.
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | string | AgentMesh runtime handle |
+| `episode_spec_hash` | string | SHA-256 of replay-normative view (§2.1) |
+| `objective` | string | Descriptive, not identity-bearing (§2.2) |
+| `inputs_hash` | string | SHA-256 of JCS(inputs) (§2.4) |
+| `script_hash` | string | SHA-256 of JCS(replay_script) (§2.4) |
+| `env_fingerprint_hash` | string | SHA-256 of identity-bearing env subset (§2.3) |
+| `replay_basis` | string | `"recorded_trace"` in v0 |
+| `comparator_tier` | string | `"A"` in v0 |
+| `n_steps` | integer | Total steps in script |
+
+### 5.2 `rce.episode_step/v0`
+
+Emitted once per step execution.
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | string | Runtime handle |
+| `step_id` | string | Step identifier from script |
+| `opcode` | string | One of: `LOAD_INPUT`, `ASSERT_HASH`, `APPLY_TRANSFORM`, `EMIT_OUTPUT` |
+| `step_status` | string | `PASS`, `FAIL`, or `SKIPPED` (§3.4) |
+| `input_hashes` | array[string] | Dependency output hashes in `depends_on` order (§2.4) |
+| `output_hash` | string | SHA-256 of JCS(step_output) (§2.4) |
+| `output_size_bytes` | integer | Size of step output |
+| `duration_ms` | integer | Step execution duration |
+| `comparator_tier` | string | Tier applied to this step |
+| `assertion_passed` | boolean | **ASSERT_HASH only.** Redundant with step_status by design. |
+| `schema_validation_error` | string | **EMIT_OUTPUT only.** Present when step_status is FAIL. |
+| `provider` | string | Optional. Provider identity for APPLY_TRANSFORM. |
+| `model_id` | string | Optional. Model identity for APPLY_TRANSFORM. |
+| `system_fingerprint` | string | Optional. Runtime-reported fingerprint (audit, not identity). |
+
+### 5.3 `rce.episode_close/v0`
+
+Emitted once at episode completion.
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | string | Runtime handle |
+| `episode_spec_hash` | string | SHA-256 of replay-normative view (§2.1) |
+| `outputs_hash` | string | SHA-256 of outputs manifest (§2.4) |
+| `n_steps_executed` | integer | Steps actually executed (not SKIPPED) |
+| `n_steps_passed` | integer | Steps with step_status PASS |
+| `all_steps_passed` | boolean | `false` if any step FAIL or SKIPPED |
+| `replay_basis` | string | `"recorded_trace"` in v0 |
+| `comparator_tier` | string | `"A"` in v0 |
+
+### 5.4 `rce.replay_result/v0`
+
+Emitted by a replay verifier (not the original executor). This receipt makes RCE a protocol, not just a format.
+
+**Parent binding rule:** `parent_hashes` MUST contain exactly one entry: the `receipt_hash` of the original `rce.episode_close/v0` receipt from the pack under verification. The verifier MUST recompute this hash from validated receipt data — MUST NOT copy from an unverified source. If integrity validation fails before `episode_close` can be verified, emit `verdict: INTEGRITY_FAIL` with `parent_hashes: []`.
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | string | Runtime handle |
+| `episode_spec_hash` | string | SHA-256 of replay-normative view |
+| `original_pack_root_sha256` | string | Evidence identity of original pack |
+| `verdict` | string | `MATCH`, `DIVERGE`, or `INTEGRITY_FAIL` (§6) |
+| `receipt_integrity` | string | `PASS` or `FAIL` |
+| `claim_check` | string | `PASS` or `FAIL` |
+| `replay_basis` | string | `"recorded_trace"` in v0 |
+| `comparator_tier` | string | `"A"` in v0 |
+| `script_hash` | string | SHA-256 of JCS(replay_script) |
+| `steps_replayed` | integer | Total steps replayed |
+| `steps_matched` | integer | Steps matching under comparator |
+| `steps_diverged` | integer | Steps that diverged |
+| `divergent_step_ids` | array[string] | IDs of divergent steps |
+| `verifier_id` | string | Verifier implementation identifier |
+| `verifier_version` | string | Verifier version |
+| `verifier_env_hash` | string | Local attestation (§2.4) |
+| `dispute` | object\|null | Dispute payload (§5.5); MUST be non-null when verdict is DIVERGE |
+
+### 5.5 Dispute Payload
+
+When `verdict` is `DIVERGE`, the `dispute` field MUST be populated:
+
+- `dispute.divergent_steps` MUST contain **at least one entry**. A `DIVERGE` verdict with empty `divergent_steps` is a protocol violation.
+- **Collection policy (v0): exhaust all steps.** The verifier MUST replay all steps before emitting a verdict. MUST NOT stop on first divergence.
+- `replay_pack_root_sha256` MUST reference the pack produced by the replay verifier.
+
+**Dispute step fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `step_id` | string | Divergent step identifier |
+| `expected_output_hash` | string | From original step receipt |
+| `observed_output_hash` | string | Recomputed by replayer |
+| `comparator_tier` | string | Tier applied |
+| `comparator_detail` | string | Human-readable mismatch description |
+
+---
+
+## 6. Verdict Semantics [Normative]
+
+RCE verdicts map onto the existing Assay two-axis contract (`receipt_integrity` × `claim_check`) to preserve Gallery, CI, and Ledger compatibility.
+
+| Verdict | `receipt_integrity` | `claim_check` | Exit Code | Gallery Label |
+|---------|:-------------------:|:-------------:|:---------:|:-------------:|
+| `MATCH` | PASS | PASS | 0 | **PASS** |
+| `DIVERGE` | PASS | FAIL | 1 | **HONEST FAIL** |
+| `INTEGRITY_FAIL` | FAIL | — | 2 | **TAMPERED** |
+
+### 6.1 Verdict Precedence
+
+`INTEGRITY_FAIL` takes precedence. If evidence integrity fails, the verifier MUST NOT attempt replay comparison.
+
+### 6.2 Mandatory Verification Order
+
+A conforming verifier MUST execute these phases in order. No phase begins until the prior completes. Failure emits the indicated verdict and stops.
+
+| Phase | Action | Failure Verdict |
+|:-----:|--------|-----------------|
+| **1** | **Script validation.** Parse Episode Contract. Validate: unique step_ids, resolved depends_on, no cycles, at least one terminal EMIT_OUTPUT. | `INTEGRITY_FAIL` |
+| **2** | **Pack integrity.** Standard Assay verification: file hashes, receipt chain, signature checks, attestation block. | `INTEGRITY_FAIL` |
+| **3** | **Completeness.** Verify artifacts present: Episode Contract, all input artifacts, one recorded trace per step. Verify receipts: one `episode_open`, one `episode_step` per step, one `episode_close`. Recompute and verify: `episode_spec_hash` (§2.1), `env_fingerprint_hash` (§2.3), `inputs_hash`, `script_hash` (§2.4), `outputs_hash` (§2.4). | `INTEGRITY_FAIL` |
+| **4** | **Replay comparison.** For each step in DAG order: verify `input_hashes` against dependency `output_hash` values in `depends_on` order; recompute step output from replay artifact; compare against receipt `output_hash` under declared comparator tier. Collect all divergences. | `DIVERGE` or `MATCH` |
+
+**Consequence:** Two conforming verifiers given the same pack, contract, and traces MUST produce the same verdict.
+
+### 6.3 What Each Verdict Proves and Does Not Prove
+
+| Verdict | Proves | Does NOT Prove |
+|---------|--------|----------------|
+| `MATCH` | Recorded outputs consistent with receipts under declared tier. Evidence intact. | Original execution correct. Objective achieved. Live re-execution same. |
+| `DIVERGE` | Evidence intact. Specific divergent steps identified. | Why divergence occurred. Semantic equivalence (requires Tier C). |
+| `INTEGRITY_FAIL` | Something wrong with the evidence. | What specifically was tampered with. |
+
+---
+
+## 7. Episode Contract Schema [Normative]
+
+See [schemas/rce_episode_contract.schema.json](./schemas/rce_episode_contract.schema.json) for the machine-readable JSON Schema.
+
+The Episode Contract is the full specification of an episode. The replay-normative view (§2.1) is a computed subset — the contract carries both normative and descriptive fields.
+
+---
+
+## 8. Compatibility [Informative]
+
+| Existing Surface | RCE Impact | Breaking? |
+|-----------------|------------|:---------:|
+| `receipt_pack.jsonl` | New receipt types added | No |
+| `pack_manifest.json` | `receipt_integrity`/`claim_check` axes preserved | No |
+| `pack_signature.sig` | Same Ed25519 signing | No |
+| CRS v0.1 envelope | Episode receipts conform | No |
+| Gallery exit codes | 0/1/2 mapping preserved | No |
+| Ledger | Packs anchored via `pack_root_sha256` | No |
+
+---
+
+## 9. Scope Boundaries [Informative]
+
+### 9.1 In Scope for v0.1
+
+- Episode Contract schema and replay-normative view
+- ReplayScript v0 with 4 opcodes
+- 4 receipt types conforming to CRS v0.1
+- Recorded-trace replay with Tier A comparison
+- Deterministic verification order (4 phases)
+- Verdict semantics mapped to Assay two-axis contract
+
+### 9.2 Explicitly Deferred
+
+- Quorum settlement (`quorum_settlement.v0`)
+- Live provider re-execution (`replay_basis: "live_reexecution"`)
+- Semantic comparison (Tier C)
+- Time anchoring (RFC 3161 / transparency logs)
+- `EpisodeRef` in AgentMesh transport
+- `episode_checkpoint.v0` for long episodes
+- Cross-repo governance semantics
+
+---
+
+## 10. Relationship to Other Documents
+
+| This Document | Other Document |
+|---------------|---------------|
+| Episode identity and replay contract | [SPEC.md](./SPEC.md) — tool safety enforcement |
+| Receipt types and envelope | [CRS v0.1](./CONSTITUTIONAL_RECEIPT_STANDARD_v0.1.md) — receipt format |
+| Verdict ↔ exit code mapping | Assay Proof Pack Contract — pack verification |
+| MCP tool actions within episodes | [MCP Minimum Profile](./MCP_MINIMUM_PROFILE.md) — gateway conformance |
+
+Implementations using RCE episodes that include MCP tool actions should satisfy both this profile and the MCP Minimum Profile.
+
+---
+
+*Assay Protocol — Replay-Constrained Episode Profile v0.1*
+*Companion to SPEC.md v1.0.0-rc1*

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,37 @@
+# Assay Profiles
+
+`profiles/registry.json` is the Assay profile discovery surface.
+
+It maps receipt families to profile metadata:
+
+```text
+receipt_type -> profile metadata -> schema path -> validator owner -> lifecycle status
+```
+
+An incubating profile is visible to Assay validation and has tests, examples, schemas, and a validator owner. Incubating does not mean the profile is a normative Constitutional Receipt Standard profile.
+
+Normative CRS promotion requires a separate promotion receipt or document. Do not mark a profile as `normative_crs_profile: true` without that explicit promotion artifact.
+
+## Registered Profiles
+
+### GLIMPS
+
+Status: incubating.
+
+GLIMPS births candidate sight but grants no authority. It registers:
+
+- `glimps.birth/v0`
+- `glimps.emission_census/v0`
+- `glimps.wound/v0`
+
+Validate through the profile validator:
+
+```bash
+python3 scripts/glimps_validate.py profiles/glimps/examples/agent_failure_birth_receipt.json --json
+```
+
+Validate through the general Assay dispatcher:
+
+```bash
+python3 scripts/assay_validate.py profiles/glimps/examples/agent_failure_birth_receipt.json --json
+```

--- a/profiles/glimps/README.md
+++ b/profiles/glimps/README.md
@@ -88,7 +88,15 @@ Emit machine-readable output:
 python3 scripts/glimps_validate.py profiles/glimps/examples/wound_receipt.json --json
 ```
 
-The validator dispatches by `receipt_type`, loads the matching schema, and enforces GLIMPS authority boundaries. It rejects unknown receipt types, authority leakage, missing rivals, missing first wounds, invalid wound routes, and census counts whose warnings do not match the counts.
+The profile validator dispatches by `receipt_type`, loads the matching schema, and enforces GLIMPS authority boundaries. It rejects unknown receipt types, authority leakage, missing rivals, missing first wounds, invalid wound routes, and census counts whose warnings do not match the counts.
+
+The general Assay validator also dispatches GLIMPS receipts:
+
+```bash
+python3 scripts/assay_validate.py profiles/glimps/examples/agent_failure_birth_receipt.json --json
+```
+
+This makes GLIMPS visible to the broader Assay validation path while keeping it incubating and non-authoritative.
 
 ## Non-Goals
 

--- a/profiles/glimps/README.md
+++ b/profiles/glimps/README.md
@@ -4,6 +4,8 @@ GLIMPS is a schema-first protocol profile for pre-claim hypothesis birth.
 
 A glimpse is not a claim. A claim is not an invariant. GLIMPS admits candidate sight into the organism without granting authority.
 
+Status: incubating Assay profile. This is not yet a normative Constitutional Receipt Standard profile.
+
 ## Doctrine
 
 - GLIMPS births candidate sight.
@@ -66,6 +68,28 @@ Promotion to a Claim Packet does not require a candidate to survive its first wo
 
 Surviving wounds belongs to Arena and Guardian, not GLIMPS.
 
+## Validation
+
+Validate one GLIMPS receipt:
+
+```bash
+python3 scripts/glimps_validate.py profiles/glimps/examples/agent_failure_birth_receipt.json
+```
+
+Validate all example receipts in a directory:
+
+```bash
+python3 scripts/glimps_validate.py profiles/glimps/examples
+```
+
+Emit machine-readable output:
+
+```bash
+python3 scripts/glimps_validate.py profiles/glimps/examples/wound_receipt.json --json
+```
+
+The validator dispatches by `receipt_type`, loads the matching schema, and enforces GLIMPS authority boundaries. It rejects unknown receipt types, authority leakage, missing rivals, missing first wounds, invalid wound routes, and census counts whose warnings do not match the counts.
+
 ## Non-Goals
 
 - No LLM calls.
@@ -80,4 +104,4 @@ Surviving wounds belongs to Arena and Guardian, not GLIMPS.
 - Map these profile receipts into the Constitutional Receipt Standard once the CRS profile registry is ready.
 - Define the Claim Packet adapter boundary after `glimps.wound/v0` examples stabilize.
 - Add optional Evidence Wire Protocol correlation fields without making this v0 depend on AgentMesh.
-- Add Assay validator support for profile-level invariant checks.
+- Decide whether `scripts/glimps_validate.py` stays profile-specific or becomes part of the general Assay validator dispatch path.

--- a/profiles/glimps/README.md
+++ b/profiles/glimps/README.md
@@ -1,0 +1,83 @@
+# GLIMPS Profile v0
+
+GLIMPS is a schema-first protocol profile for pre-claim hypothesis birth.
+
+A glimpse is not a claim. A claim is not an invariant. GLIMPS admits candidate sight into the organism without granting authority.
+
+## Doctrine
+
+- GLIMPS births candidate sight.
+- Claim Packets admit structured claims.
+- Arena wounds candidates.
+- Guardian scopes authority.
+- Assay remembers.
+- Quintet evolves the law.
+
+GLIMPS lands protocol-first because it is upstream of authority. It must not mutate Loom runtime state, MemoryGraph, Guardian policy, or default routes.
+
+## Core Law
+
+- Fertility may request attention.
+- Fertility may not allocate budget.
+- Only receipts may buy confidence.
+- Only wounds may buy authority.
+- Beauty may point, but never testify.
+- Ghosts may seed, but never govern.
+
+## Artifact Chain
+
+```text
+Glimpse Packet -> Claim Packet -> Wound Receipt -> Guardian Decision -> Archive/Ghost
+```
+
+## Receipt Types
+
+### `glimps.birth/v0`
+
+Records a Glimpse Packet: the pressure, lens, candidate frame, rivals, first wound, permissions, attention request, lens debt, and negative duties.
+
+### `glimps.emission_census/v0`
+
+Audits the birth-side coverage of a GLIMPS run. It catches silent non-generation, frame monoculture, rival suppression, unwounded candidates, attention capture, and fertility-confidence confusion.
+
+### `glimps.wound/v0`
+
+Records an Arena probe against a glimpse candidate. A wound receipt links back to the birth receipt by `glimpse_id`.
+
+## Object Ladder
+
+```text
+spark
+pressure_note
+lens
+candidate_hypothesis
+proof_program
+```
+
+Promotion to a Claim Packet does not require a candidate to survive its first wound. It requires woundability:
+
+- pressure named
+- lens blindness recorded
+- at least one rival
+- first wound specified
+- cheap probe available
+- permissions locked down
+- promotion requirements declared
+
+Surviving wounds belongs to Arena and Guardian, not GLIMPS.
+
+## Non-Goals
+
+- No LLM calls.
+- No Guardian integration.
+- No Loom MemoryGraph mutation.
+- No runtime authority.
+- No policy mutation.
+- No claim that a glimpse proves truth.
+
+## Adapter TODOs
+
+- Map these profile receipts into the Constitutional Receipt Standard once the CRS profile registry is ready.
+- Define the Claim Packet adapter boundary after `glimps.wound/v0` examples stabilize.
+- Add optional Evidence Wire Protocol correlation fields without making this v0 depend on AgentMesh.
+- Add Assay validator support for profile-level invariant checks.

--- a/profiles/glimps/README.md
+++ b/profiles/glimps/README.md
@@ -6,6 +6,8 @@ A glimpse is not a claim. A claim is not an invariant. GLIMPS admits candidate s
 
 Status: incubating Assay profile. This is not yet a normative Constitutional Receipt Standard profile.
 
+GLIMPS is registered in `profiles/registry.json` as an Assay-visible incubating profile family.
+
 ## Doctrine
 
 - GLIMPS births candidate sight.

--- a/profiles/glimps/examples/agent_failure_birth_receipt.json
+++ b/profiles/glimps/examples/agent_failure_birth_receipt.json
@@ -1,0 +1,80 @@
+{
+  "receipt_type": "glimps.birth/v0",
+  "glimpse_id": "G_agent_failure_001",
+  "object_level": "candidate_hypothesis",
+  "niche": "agent_failure",
+  "truth_track": "taxonomy",
+  "source_pressure": ["repeated_failure", "authority_leakage", "overfit_zoo"],
+  "pressure_statement": "Agent failures labeled as provider drift, memory contamination, and evaluator disagreement are being collapsed into one noisy failure class.",
+  "lens": {
+    "name": "regime_fragmentation",
+    "makes_visible": ["clustered failure modes", "overloaded explanations", "receipt signature differences"],
+    "hides": ["single root-cause bugs", "one-off infrastructure instability"],
+    "distortion_risk": "May split one failure mode into too many regimes."
+  },
+  "lens_debt": {
+    "likely_false_positives": ["ordinary variance interpreted as a distinct regime"],
+    "likely_false_negatives": ["shared causal root hidden behind different symptoms"],
+    "overuse_failure_mode": "Taxonomy expands faster than testable constraints.",
+    "counter_lens": "single_fault_tree"
+  },
+  "candidate_claim_or_frame": "These failures may be multiple regimes rather than one noisy process.",
+  "imagination_type": ["factorizing", "taxonomic", "adversarial"],
+  "proposer": {
+    "kind": "hybrid",
+    "id": "glimps-v0-example"
+  },
+  "mechanism": "If real, each regime should leave a different receipt signature and respond differently to replay, provider swap, and memory isolation.",
+  "rivals": [
+    {
+      "rival_id": "R1",
+      "frame": "The pattern is a representation artifact from coarse labels."
+    },
+    {
+      "rival_id": "R2",
+      "frame": "A single verifier bug creates the apparent taxonomy."
+    }
+  ],
+  "first_wound": {
+    "smallest_test": "Replay three failing episodes with memory isolation and compare receipt signatures.",
+    "what_would_hurt": "All alleged regimes show the same receipt signature under replay.",
+    "what_it_forbids": "Provider drift, memory contamination, and evaluator disagreement collapsing to identical traces after isolation."
+  },
+  "confidence": "low",
+  "fertility": "high",
+  "initial_authority": "speculative",
+  "attention_request": {
+    "requested": true,
+    "reason": "A tiny replay probe could reduce the failure zoo into separable regimes.",
+    "budget_class": "tiny_probe",
+    "requires_gate": true
+  },
+  "permissions": {
+    "can_inspire_search": true,
+    "can_generate_tests": true,
+    "can_prioritize_search": true,
+    "can_allocate_execution_budget": false,
+    "can_change_default_route": false,
+    "can_govern_execution": false,
+    "can_modify_policy": false,
+    "can_raise_confidence_without_receipts": false,
+    "requires_receipts_for_promotion": true
+  },
+  "negative_duties": {
+    "must_not_raise_confidence": true,
+    "must_not_suppress_rivals": true,
+    "must_not_mutate_memory": true,
+    "must_not_modify_policy": true,
+    "must_not_claim_exhaustive_search": true,
+    "must_not_present_beauty_as_evidence": true
+  },
+  "related_ghosts": [],
+  "promotion_requirements": [
+    "Pressure is named.",
+    "Lens blindness is recorded.",
+    "At least one rival is present.",
+    "First wound is specified.",
+    "Cheap probe is available.",
+    "Permissions are locked down."
+  ]
+}

--- a/profiles/glimps/examples/emission_census.json
+++ b/profiles/glimps/examples/emission_census.json
@@ -1,0 +1,17 @@
+{
+  "receipt_type": "glimps.emission_census/v0",
+  "pressure_id": "P_agent_failure_001",
+  "pressures_detected": 3,
+  "glimpses_generated": 5,
+  "lenses_generated": 4,
+  "candidates_generated": 3,
+  "candidates_with_rivals": 3,
+  "candidates_with_first_wounds": 3,
+  "pressures_without_candidates": [],
+  "dominant_lens_family": "regime_fragmentation",
+  "frame_monoculture_warning": false,
+  "attention_capture_warning": false,
+  "rival_suppression_warning": false,
+  "unwounded_candidate_warning": false,
+  "fertility_confidence_confusion_warning": false
+}

--- a/profiles/glimps/examples/ghost_reactivation_birth_receipt.json
+++ b/profiles/glimps/examples/ghost_reactivation_birth_receipt.json
@@ -1,0 +1,85 @@
+{
+  "receipt_type": "glimps.birth/v0",
+  "glimpse_id": "G_ghost_reactivation_001",
+  "object_level": "candidate_hypothesis",
+  "niche": "memory",
+  "truth_track": "usefulness",
+  "source_pressure": ["ghost_reactivation", "recurring_metaphor", "repeated_failure"],
+  "pressure_statement": "A previously archived frame keeps matching new failures, but it never received a clean wound under the current receipt regime.",
+  "lens": {
+    "name": "ghost_seed_under_new_pressure",
+    "makes_visible": ["old failure signal", "new receipt requirements", "unreceived wounds"],
+    "hides": ["nostalgia for a dead frame", "semantic drift in reused vocabulary"],
+    "distortion_risk": "May let a familiar ghost feel wiser than the new evidence warrants."
+  },
+  "lens_debt": {
+    "likely_false_positives": ["shared language mistaken for shared mechanism"],
+    "likely_false_negatives": ["a useful ghost rejected because it failed under an older representation"],
+    "overuse_failure_mode": "Archived ideas sneak back into governance by familiarity.",
+    "counter_lens": "fresh_pressure_no_archive"
+  },
+  "candidate_claim_or_frame": "The archived frame may still be useful as a search lens if it is reintroduced only through new receipts and new wounds.",
+  "imagination_type": ["ghost_revival", "counterfactual"],
+  "proposer": {
+    "kind": "human",
+    "id": "glimps-v0-example"
+  },
+  "mechanism": "If useful, the ghost should predict a new probe outcome that was not available when it was archived.",
+  "rivals": [
+    {
+      "rival_id": "R1",
+      "frame": "The ghost is only a recurring metaphor with no new mechanism."
+    },
+    {
+      "rival_id": "R2",
+      "frame": "The new pressure is better explained by a fresh lens."
+    }
+  ],
+  "first_wound": {
+    "smallest_test": "Run one new receipt-backed probe the archived frame did not previously face.",
+    "what_would_hurt": "The ghost fails to predict anything different from the fresh counter-lens.",
+    "what_it_forbids": "Reactivation without new receipts."
+  },
+  "confidence": "low",
+  "fertility": "medium",
+  "initial_authority": "speculative",
+  "attention_request": {
+    "requested": true,
+    "reason": "The ghost may seed one cheap probe, but it cannot govern without new receipts.",
+    "budget_class": "tiny_probe",
+    "requires_gate": true
+  },
+  "permissions": {
+    "can_inspire_search": true,
+    "can_generate_tests": true,
+    "can_prioritize_search": true,
+    "can_allocate_execution_budget": false,
+    "can_change_default_route": false,
+    "can_govern_execution": false,
+    "can_modify_policy": false,
+    "can_raise_confidence_without_receipts": false,
+    "requires_receipts_for_promotion": true
+  },
+  "negative_duties": {
+    "must_not_raise_confidence": true,
+    "must_not_suppress_rivals": true,
+    "must_not_mutate_memory": true,
+    "must_not_modify_policy": true,
+    "must_not_claim_exhaustive_search": true,
+    "must_not_present_beauty_as_evidence": true
+  },
+  "related_ghosts": [
+    {
+      "ghost_id": "GH_old_frame_001",
+      "new_receipts": ["receipt:new-pressure-001"]
+    }
+  ],
+  "promotion_requirements": [
+    "Pressure is named.",
+    "Lens blindness is recorded.",
+    "At least one rival is present.",
+    "First wound is specified.",
+    "Cheap probe is available.",
+    "New receipts exist for ghost reactivation."
+  ]
+}

--- a/profiles/glimps/examples/math_birth_receipt.json
+++ b/profiles/glimps/examples/math_birth_receipt.json
@@ -1,0 +1,80 @@
+{
+  "receipt_type": "glimps.birth/v0",
+  "glimpse_id": "G_math_001",
+  "object_level": "candidate_hypothesis",
+  "niche": "math",
+  "truth_track": "obstruction",
+  "source_pressure": ["proof_dead_end", "beautiful_near_miss", "missing_invariant"],
+  "pressure_statement": "Several small cases obey the pattern, but every direct induction attempt accumulates exception handling rather than reducing it.",
+  "lens": {
+    "name": "obstruction_as_object",
+    "makes_visible": ["proof gaps as structured data", "boundary cases", "candidate invariants"],
+    "hides": ["simple computational mistakes", "accidental low-range coincidences"],
+    "distortion_risk": "May over-interpret a failed proof strategy as evidence of a real obstruction."
+  },
+  "lens_debt": {
+    "likely_false_positives": ["noise in small cases treated as structure"],
+    "likely_false_negatives": ["a direct proof that bypasses the obstruction vocabulary"],
+    "overuse_failure_mode": "Every failed proof begins to look like a deep missing invariant.",
+    "counter_lens": "brute_force_small_cases"
+  },
+  "candidate_claim_or_frame": "The pattern may be governed by an obstruction invariant rather than by the visible recurrence.",
+  "imagination_type": ["obstruction", "geometric"],
+  "proposer": {
+    "kind": "hybrid",
+    "id": "glimps-v0-example"
+  },
+  "mechanism": "If real, the obstruction should stay stable under transformations that preserve the hidden invariant and fail under transformations that break it.",
+  "rivals": [
+    {
+      "rival_id": "R1",
+      "frame": "The pattern is an artifact of the chosen representation."
+    },
+    {
+      "rival_id": "R2",
+      "frame": "The result is locally true in the checked range but globally false."
+    }
+  ],
+  "first_wound": {
+    "smallest_test": "Compute the next boundary family where the recurrence changes regime.",
+    "what_would_hurt": "A boundary case that satisfies the recurrence but violates the proposed obstruction.",
+    "what_it_forbids": "The same obstruction score appearing in both successful and failed cases."
+  },
+  "confidence": "low",
+  "fertility": "high",
+  "initial_authority": "speculative",
+  "attention_request": {
+    "requested": true,
+    "reason": "High search yield if the obstruction vocabulary separates boundary cases.",
+    "budget_class": "tiny_probe",
+    "requires_gate": true
+  },
+  "permissions": {
+    "can_inspire_search": true,
+    "can_generate_tests": true,
+    "can_prioritize_search": true,
+    "can_allocate_execution_budget": false,
+    "can_change_default_route": false,
+    "can_govern_execution": false,
+    "can_modify_policy": false,
+    "can_raise_confidence_without_receipts": false,
+    "requires_receipts_for_promotion": true
+  },
+  "negative_duties": {
+    "must_not_raise_confidence": true,
+    "must_not_suppress_rivals": true,
+    "must_not_mutate_memory": true,
+    "must_not_modify_policy": true,
+    "must_not_claim_exhaustive_search": true,
+    "must_not_present_beauty_as_evidence": true
+  },
+  "related_ghosts": [],
+  "promotion_requirements": [
+    "Pressure is named.",
+    "Lens blindness is recorded.",
+    "At least one rival is present.",
+    "First wound is specified.",
+    "Cheap probe is available.",
+    "Permissions are locked down."
+  ]
+}

--- a/profiles/glimps/examples/wound_receipt.json
+++ b/profiles/glimps/examples/wound_receipt.json
@@ -1,0 +1,15 @@
+{
+  "receipt_type": "glimps.wound/v0",
+  "glimpse_id": "G_agent_failure_001",
+  "candidate_id": "H_agent_failure_001",
+  "wound_id": "W_agent_failure_replay_001",
+  "probe_type": "representation_check",
+  "expected_result": "If regime fragmentation is useful, isolated replay should produce distinct receipt signatures for at least two alleged regimes.",
+  "observed_result": "Provider drift and memory contamination cases separated under memory isolation; evaluator disagreement remained inconclusive.",
+  "wound_result": "survived",
+  "new_questions": [
+    "Does evaluator disagreement require a separate verifier fixture?",
+    "Do provider swaps preserve the same separation?"
+  ],
+  "next_route": "run_more_wounds"
+}

--- a/profiles/glimps/prompts/glimps_agent_failure.md
+++ b/profiles/glimps/prompts/glimps_agent_failure.md
@@ -1,0 +1,21 @@
+# GLIMPS Agent Failure Prompt
+
+Run GLIMPS on the agent failure pressure below.
+
+Return Glimpse Packets only. Do not turn a candidate into a runtime rule.
+
+## Steps
+
+1. Gather pressure: name the observed failure, silent non-emission, confidence leak, route drift, receipt gap, memory contamination, or evaluator disagreement.
+2. Look through lenses: provider drift, memory jurisdiction, adversarial adaptation, stochastic infrastructure, policy ambiguity, evidence loss, orchestration race, user intent mismatch.
+3. Invent or invert objects: ask whether the failure class is wrong, overloaded, or hiding multiple regimes.
+4. Make mechanisms and rivals: identify plausible mechanisms and rival explanations.
+5. Probe for first wounds: define the cheapest replay, receipt census, fixture, or negative case.
+6. Seal the seed: include attention request, negative duties, lens debt, rivals, and first wound.
+
+## Guardrails
+
+- Fertility cannot raise confidence.
+- Ghosts may seed only with new pressure and new receipts.
+- Aesthetic fit is not evidence.
+- GLIMPS births candidates; Arena wounds them.

--- a/profiles/glimps/prompts/glimps_math.md
+++ b/profiles/glimps/prompts/glimps_math.md
@@ -1,0 +1,21 @@
+# GLIMPS Math Prompt
+
+Run GLIMPS on the mathematical pressure below.
+
+Return Glimpse Packets only. Do not claim proof, confidence, or authority.
+
+## Steps
+
+1. Gather pressure: name the anomaly, proof dead-end, ugly complexity, near-miss, missing invariant, or overfit zoo.
+2. Look through non-equivalent lenses: algebraic, geometric, combinatorial, topological, dynamical, game, obstruction, boundary object, symmetry action.
+3. Invent or invert objects: ask what object should exist so the statement becomes natural.
+4. Make mechanisms and rivals: birth at least two rival frames.
+5. Probe for first wounds: specify the cheapest small case, counterexample, boundary case, or representation check.
+6. Seal the seed: state confidence and fertility separately, lock permissions, and record lens debt.
+
+## Guardrails
+
+- A glimpse is not a proof.
+- Beauty may select attention, but may not testify.
+- Analogy requires a non-analogical wound.
+- Fertility may request a tiny probe, but may not allocate budget.

--- a/profiles/glimps/prompts/glimps_systems.md
+++ b/profiles/glimps/prompts/glimps_systems.md
@@ -1,0 +1,21 @@
+# GLIMPS Systems Prompt
+
+Run GLIMPS on the systems or architecture pressure below.
+
+Return Glimpse Packets only. Do not mutate policy, default routes, memory, or runtime behavior.
+
+## Steps
+
+1. Gather pressure: name the contradiction, brittle boundary, repeated failure, authority leak, or complexity knot.
+2. Look through lenses: jurisdiction, evidence, incentives, fault isolation, state ownership, protocol boundary, lifecycle, rollback, adversary.
+3. Invent or invert objects: make the failure, obstruction, or missing invariant into the object.
+4. Make mechanisms and rivals: explain what process would produce the pattern, then generate rival explanations.
+5. Probe for first wounds: define the smallest trace, fixture, receipt, or counterexample that can hurt the candidate.
+6. Seal the seed: separate confidence from fertility and require a budget gate for anything beyond search priority.
+
+## Guardrails
+
+- A glimpse cannot govern execution.
+- A glimpse cannot change the default route.
+- Attention is soft authority.
+- Budget requires a gate.

--- a/profiles/glimps/schema/glimpse_birth_receipt.v0.json
+++ b/profiles/glimps/schema/glimpse_birth_receipt.v0.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Haserjian/assay/profiles/glimps/schema/glimpse_birth_receipt.v0.json",
+  "title": "GLIMPS Birth Receipt v0",
+  "description": "A Glimpse Packet records pre-claim candidate sight without granting authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_type",
+    "glimpse_id",
+    "object_level",
+    "niche",
+    "truth_track",
+    "source_pressure",
+    "pressure_statement",
+    "lens",
+    "lens_debt",
+    "candidate_claim_or_frame",
+    "imagination_type",
+    "proposer",
+    "mechanism",
+    "rivals",
+    "first_wound",
+    "confidence",
+    "fertility",
+    "initial_authority",
+    "attention_request",
+    "permissions",
+    "negative_duties",
+    "related_ghosts",
+    "promotion_requirements"
+  ],
+  "properties": {
+    "receipt_type": {
+      "type": "string",
+      "enum": ["glimps.birth/v0"]
+    },
+    "glimpse_id": {
+      "type": "string",
+      "pattern": "^G_[A-Za-z0-9._-]+$"
+    },
+    "object_level": {
+      "type": "string",
+      "enum": ["spark", "pressure_note", "lens", "candidate_hypothesis", "proof_program"]
+    },
+    "niche": {
+      "type": "string",
+      "enum": [
+        "math",
+        "agent_failure",
+        "policy",
+        "memory",
+        "receipt_integrity",
+        "provider_routing",
+        "proof_search",
+        "market_constraint",
+        "human_workflow",
+        "systems"
+      ]
+    },
+    "truth_track": {
+      "type": "string",
+      "enum": ["truth", "usefulness", "representation", "obstruction", "taxonomy"]
+    },
+    "source_pressure": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "pressure_statement": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lens": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "makes_visible", "hides", "distortion_risk"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "makes_visible": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "hides": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "distortion_risk": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "lens_debt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "likely_false_positives",
+        "likely_false_negatives",
+        "overuse_failure_mode",
+        "counter_lens"
+      ],
+      "properties": {
+        "likely_false_positives": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "likely_false_negatives": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "overuse_failure_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "counter_lens": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "candidate_claim_or_frame": {
+      "type": "string",
+      "minLength": 1
+    },
+    "imagination_type": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "analogical",
+          "geometric",
+          "adversarial",
+          "factorizing",
+          "taxonomic",
+          "obstruction",
+          "generative",
+          "mechanistic",
+          "symmetry",
+          "ghost_revival",
+          "counterfactual",
+          "system_mapping"
+        ]
+      }
+    },
+    "proposer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["human", "ai", "hybrid", "search_agent", "proof_agent"]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "mechanism": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rivals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rival_id", "frame"],
+        "properties": {
+          "rival_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "frame": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "first_wound": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["smallest_test", "what_would_hurt", "what_it_forbids"],
+      "properties": {
+        "smallest_test": {
+          "type": "string",
+          "minLength": 1
+        },
+        "what_would_hurt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "what_it_forbids": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "fertility": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "initial_authority": {
+      "type": "string",
+      "enum": ["speculative"]
+    },
+    "attention_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requested", "reason", "budget_class", "requires_gate"],
+      "properties": {
+        "requested": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "budget_class": {
+          "type": "string",
+          "enum": ["tiny_probe", "sandbox", "arena_run"]
+        },
+        "requires_gate": {
+          "type": "boolean",
+          "enum": [true]
+        }
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "can_inspire_search",
+        "can_generate_tests",
+        "can_prioritize_search",
+        "can_allocate_execution_budget",
+        "can_change_default_route",
+        "can_govern_execution",
+        "can_modify_policy",
+        "can_raise_confidence_without_receipts",
+        "requires_receipts_for_promotion"
+      ],
+      "properties": {
+        "can_inspire_search": {
+          "type": "boolean"
+        },
+        "can_generate_tests": {
+          "type": "boolean"
+        },
+        "can_prioritize_search": {
+          "type": "boolean"
+        },
+        "can_allocate_execution_budget": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "can_change_default_route": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "can_govern_execution": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "can_modify_policy": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "can_raise_confidence_without_receipts": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "requires_receipts_for_promotion": {
+          "type": "boolean",
+          "enum": [true]
+        }
+      }
+    },
+    "negative_duties": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "must_not_raise_confidence",
+        "must_not_suppress_rivals",
+        "must_not_mutate_memory",
+        "must_not_modify_policy",
+        "must_not_claim_exhaustive_search",
+        "must_not_present_beauty_as_evidence"
+      ],
+      "properties": {
+        "must_not_raise_confidence": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "must_not_suppress_rivals": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "must_not_mutate_memory": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "must_not_modify_policy": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "must_not_claim_exhaustive_search": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "must_not_present_beauty_as_evidence": {
+          "type": "boolean",
+          "enum": [true]
+        }
+      }
+    },
+    "related_ghosts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ghost_id", "new_receipts"],
+        "properties": {
+          "ghost_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "new_receipts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "promotion_requirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/profiles/glimps/schema/glimpse_emission_census.v0.json
+++ b/profiles/glimps/schema/glimpse_emission_census.v0.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Haserjian/assay/profiles/glimps/schema/glimpse_emission_census.v0.json",
+  "title": "GLIMPS Emission Census v0",
+  "description": "Birth-side coverage audit for a GLIMPS run.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_type",
+    "pressure_id",
+    "pressures_detected",
+    "glimpses_generated",
+    "lenses_generated",
+    "candidates_generated",
+    "candidates_with_rivals",
+    "candidates_with_first_wounds",
+    "pressures_without_candidates",
+    "dominant_lens_family",
+    "frame_monoculture_warning",
+    "attention_capture_warning",
+    "rival_suppression_warning",
+    "unwounded_candidate_warning",
+    "fertility_confidence_confusion_warning"
+  ],
+  "properties": {
+    "receipt_type": {
+      "type": "string",
+      "enum": ["glimps.emission_census/v0"]
+    },
+    "pressure_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pressures_detected": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "glimpses_generated": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lenses_generated": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "candidates_generated": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "candidates_with_rivals": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "candidates_with_first_wounds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pressures_without_candidates": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "dominant_lens_family": {
+      "type": "string",
+      "minLength": 1
+    },
+    "frame_monoculture_warning": {
+      "type": "boolean"
+    },
+    "attention_capture_warning": {
+      "type": "boolean"
+    },
+    "rival_suppression_warning": {
+      "type": "boolean"
+    },
+    "unwounded_candidate_warning": {
+      "type": "boolean"
+    },
+    "fertility_confidence_confusion_warning": {
+      "type": "boolean"
+    }
+  }
+}

--- a/profiles/glimps/schema/glimpse_wound_receipt.v0.json
+++ b/profiles/glimps/schema/glimpse_wound_receipt.v0.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Haserjian/assay/profiles/glimps/schema/glimpse_wound_receipt.v0.json",
+  "title": "GLIMPS Wound Receipt v0",
+  "description": "A first probe or Arena wound applied to a GLIMPS candidate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_type",
+    "glimpse_id",
+    "candidate_id",
+    "wound_id",
+    "probe_type",
+    "expected_result",
+    "observed_result",
+    "wound_result",
+    "new_questions",
+    "next_route"
+  ],
+  "properties": {
+    "receipt_type": {
+      "type": "string",
+      "enum": ["glimps.wound/v0"]
+    },
+    "glimpse_id": {
+      "type": "string",
+      "pattern": "^G_[A-Za-z0-9._-]+$"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^H_[A-Za-z0-9._-]+$"
+    },
+    "wound_id": {
+      "type": "string",
+      "pattern": "^W_[A-Za-z0-9._-]+$"
+    },
+    "probe_type": {
+      "type": "string",
+      "enum": [
+        "small_case",
+        "counterexample",
+        "rival_test",
+        "boundary_case",
+        "representation_check"
+      ]
+    },
+    "expected_result": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observed_result": {
+      "type": "string",
+      "minLength": 1
+    },
+    "wound_result": {
+      "type": "string",
+      "enum": ["survived", "weakened", "killed", "inconclusive"]
+    },
+    "new_questions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_route": {
+      "type": "string",
+      "enum": [
+        "promote_to_claim_packet",
+        "revise",
+        "archive_as_ghost",
+        "run_more_wounds"
+      ]
+    }
+  }
+}

--- a/profiles/registry.json
+++ b/profiles/registry.json
@@ -1,0 +1,59 @@
+{
+  "profiles": {
+    "glimps": {
+      "status": "incubating",
+      "normative_crs_profile": false,
+      "description": "GLIMPS births candidate sight but grants no authority.",
+      "receipt_types": {
+        "glimps.birth/v0": {
+          "receipt_type": "glimps.birth/v0",
+          "profile": "glimps",
+          "profile_status": "incubating",
+          "normative_crs_profile": false,
+          "schema_path": "profiles/glimps/schema/glimpse_birth_receipt.v0.json",
+          "validator": "scripts/glimps_validate.py",
+          "example_path": "profiles/glimps/examples/agent_failure_birth_receipt.json",
+          "description": "Records a Glimpse Packet: candidate sight with pressure, lens, rivals, first wound, permissions, and negative duties.",
+          "authority_boundary": {
+            "can_govern_execution": false,
+            "can_modify_policy": false,
+            "can_allocate_execution_budget": false,
+            "can_raise_confidence_without_receipts": false
+          }
+        },
+        "glimps.emission_census/v0": {
+          "receipt_type": "glimps.emission_census/v0",
+          "profile": "glimps",
+          "profile_status": "incubating",
+          "normative_crs_profile": false,
+          "schema_path": "profiles/glimps/schema/glimpse_emission_census.v0.json",
+          "validator": "scripts/glimps_validate.py",
+          "example_path": "profiles/glimps/examples/emission_census.json",
+          "description": "Audits GLIMPS birth-side coverage, including frame monoculture, rival suppression, and unwounded candidate warnings.",
+          "authority_boundary": {
+            "can_govern_execution": false,
+            "can_modify_policy": false,
+            "can_allocate_execution_budget": false,
+            "can_raise_confidence_without_receipts": false
+          }
+        },
+        "glimps.wound/v0": {
+          "receipt_type": "glimps.wound/v0",
+          "profile": "glimps",
+          "profile_status": "incubating",
+          "normative_crs_profile": false,
+          "schema_path": "profiles/glimps/schema/glimpse_wound_receipt.v0.json",
+          "validator": "scripts/glimps_validate.py",
+          "example_path": "profiles/glimps/examples/wound_receipt.json",
+          "description": "Records an Arena probe result for a GLIMPS candidate without granting authority.",
+          "authority_boundary": {
+            "can_govern_execution": false,
+            "can_modify_policy": false,
+            "can_allocate_execution_budget": false,
+            "can_raise_confidence_without_receipts": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/rce_episode_contract.schema.json
+++ b/schemas/rce_episode_contract.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Haserjian/assay-protocol/schemas/rce_episode_contract.schema.json",
+  "title": "RCE Episode Contract v0.1",
+  "description": "Schema for a Replay-Constrained Episode Contract. The replay-normative view (inputs, replay_script, replay_policy, identity-bearing environment subset) determines episode_spec_hash.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "episode_id",
+    "inputs",
+    "replay_script",
+    "replay_policy",
+    "environment"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "rce/0.1",
+      "description": "Envelope version. Not part of replay-normative view."
+    },
+    "episode_id": {
+      "type": "string",
+      "pattern": "^ep_[0-9a-f]{24}$",
+      "description": "AgentMesh-native time-sortable identifier. Not part of replay-normative view."
+    },
+    "objective": {
+      "type": "string",
+      "description": "Human-readable episode objective. Descriptive only — MUST NOT affect episode_spec_hash or replay verification."
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/input_ref"
+      },
+      "description": "Immutable input references. Part of replay-normative view."
+    },
+    "replay_script": {
+      "$ref": "#/definitions/replay_script",
+      "description": "Typed step DAG. Part of replay-normative view."
+    },
+    "replay_policy": {
+      "$ref": "#/definitions/replay_policy",
+      "description": "Comparator and replay basis configuration. Part of replay-normative view."
+    },
+    "environment": {
+      "$ref": "#/definitions/environment",
+      "description": "Execution environment. Identity-bearing subset (provider, model_id, tool_versions, container_digest) is part of replay-normative view."
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "input_ref": {
+      "type": "object",
+      "required": ["ref", "hash"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "description": "Logical input name"
+        },
+        "hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "SHA-256 of input bytes"
+        },
+        "media_type": {
+          "type": "string",
+          "description": "MIME type of input"
+        }
+      },
+      "additionalProperties": false
+    },
+    "replay_script": {
+      "type": "object",
+      "required": ["schema_version", "steps"],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "replay_script/0.1"
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/step"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "step": {
+      "type": "object",
+      "required": ["step_id", "opcode", "params", "depends_on"],
+      "properties": {
+        "step_id": {
+          "type": "string",
+          "description": "Unique step identifier within this script"
+        },
+        "opcode": {
+          "type": "string",
+          "enum": ["LOAD_INPUT", "ASSERT_HASH", "APPLY_TRANSFORM", "EMIT_OUTPUT"]
+        },
+        "params": {
+          "type": "object",
+          "description": "Opcode-specific parameters"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Step IDs this step depends on. Empty array for root steps."
+        },
+        "output_schema": {
+          "description": "Optional JSON Schema for step output validation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "replay_policy": {
+      "type": "object",
+      "required": ["replay_basis", "comparator_tier"],
+      "properties": {
+        "replay_basis": {
+          "type": "string",
+          "enum": ["recorded_trace"],
+          "description": "v0.1 supports recorded_trace only"
+        },
+        "comparator_tier": {
+          "type": "string",
+          "enum": ["A"],
+          "description": "v0.1 supports Tier A only"
+        },
+        "comparator_tiers_by_step": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["A"]
+          },
+          "description": "Per-step comparator tier overrides. All must be A in v0.1."
+        }
+      },
+      "additionalProperties": false
+    },
+    "environment": {
+      "type": "object",
+      "required": ["env_fingerprint_hash", "provider", "model_id", "tool_versions", "container_digest"],
+      "properties": {
+        "env_fingerprint_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "SHA-256 of JCS({provider, model_id, tool_versions, container_digest}). Derived cross-check — not a direct identity input."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Model provider identifier. Identity-bearing."
+        },
+        "model_id": {
+          "type": "string",
+          "description": "Model identifier. Identity-bearing."
+        },
+        "model_version_hint": {
+          "type": ["string", "null"],
+          "description": "Advisory model version. NOT identity-bearing."
+        },
+        "system_fingerprint": {
+          "type": ["string", "null"],
+          "description": "Runtime-reported fingerprint. NOT identity-bearing."
+        },
+        "tool_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tool name to semver mapping. Identity-bearing."
+        },
+        "container_digest": {
+          "type": ["string", "null"],
+          "description": "Container digest if applicable. Identity-bearing."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/rce_episode_contract.schema.json
+++ b/schemas/rce_episode_contract.schema.json
@@ -94,7 +94,7 @@
       "properties": {
         "step_id": {
           "type": "string",
-          "description": "Unique step identifier within this script"
+          "description": "Unique step identifier within this script. Verifier MUST enforce uniqueness across steps (JSON Schema cannot express cross-item field uniqueness)."
         },
         "opcode": {
           "type": "string",
@@ -102,20 +102,40 @@
         },
         "params": {
           "type": "object",
-          "description": "Opcode-specific parameters"
+          "description": "Opcode-specific parameters. Required fields vary by opcode — see allOf constraint below."
         },
         "depends_on": {
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           },
-          "description": "Step IDs this step depends on. Empty array for root steps."
+          "description": "Step IDs this step depends on. Empty array for root steps. No duplicate entries."
         },
         "output_schema": {
-          "description": "Optional JSON Schema for step output validation"
+          "type": "object",
+          "description": "Optional JSON Schema (draft-07) for step output validation. Must be a valid JSON Schema object if present."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": { "properties": { "opcode": { "const": "LOAD_INPUT" } } },
+          "then": { "properties": { "params": { "required": ["ref"] } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "ASSERT_HASH" } } },
+          "then": { "properties": { "params": { "required": ["target", "expected_hash"] } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "APPLY_TRANSFORM" } } },
+          "then": { "properties": { "params": { "required": ["transform"] } } }
+        },
+        {
+          "if": { "properties": { "opcode": { "const": "EMIT_OUTPUT" } } },
+          "then": { "properties": { "params": { "required": ["claim_type", "output_ref"] } } }
+        }
+      ]
     },
     "replay_policy": {
       "type": "object",

--- a/scripts/assay_validate.py
+++ b/scripts/assay_validate.py
@@ -40,6 +40,16 @@ except ImportError:
     )
 
 
+try:
+    from glimps_validate import SCHEMA_BY_RECEIPT_TYPE as GLIMPS_RECEIPT_TYPES
+    from glimps_validate import validate_glimps_receipt
+except ImportError:
+    # Keep the gateway conformance validator usable even when profile validators
+    # are not installed on a copied script path.
+    GLIMPS_RECEIPT_TYPES = {}
+    validate_glimps_receipt = None
+
+
 # =============================================================================
 # Assay Behavioral Requirements (from SPEC.md)
 # =============================================================================
@@ -463,6 +473,98 @@ def validate_receipts(receipts: list[dict]) -> ConformanceReport:
     return report
 
 
+def is_glimps_receipt_type(receipt_type: object) -> bool:
+    """Return true for receipt types owned by the GLIMPS profile namespace."""
+    return isinstance(receipt_type, str) and receipt_type.startswith("glimps.")
+
+
+def dispatch_profile_validation(receipts: list[dict]) -> Optional[dict]:
+    """Dispatch profile-owned receipts to their profile validator.
+
+    Returns None when no profile owns the receipts, preserving the legacy Assay
+    Tool Safety Profile conformance path for ordinary gateway receipts.
+    """
+    receipt_types = [receipt.get("receipt_type", "<missing>") for receipt in receipts]
+    malformed_receipt_types = [
+        {
+            "ok": False,
+            "receipt_type": receipt_type,
+            "profile": "unknown",
+            "errors": ["receipt_type: must be a string"],
+        }
+        for receipt_type in receipt_types
+        if not isinstance(receipt_type, str)
+    ]
+    if malformed_receipt_types:
+        if len(malformed_receipt_types) == 1 and len(receipt_types) == 1:
+            return malformed_receipt_types[0]
+        return {
+            "ok": False,
+            "profile": "unknown",
+            "errors": ["receipt_type: must be a string"],
+            "results": malformed_receipt_types,
+        }
+
+    if not any(is_glimps_receipt_type(receipt_type) for receipt_type in receipt_types):
+        return None
+
+    if not all(is_glimps_receipt_type(receipt_type) for receipt_type in receipt_types):
+        return {
+            "ok": False,
+            "profile": "mixed",
+            "errors": ["cannot mix GLIMPS profile receipts with non-GLIMPS receipts"],
+            "results": [
+                {
+                    "ok": False,
+                    "receipt_type": receipt_type,
+                    "profile": "glimps" if is_glimps_receipt_type(receipt_type) else "unknown",
+                    "errors": ["mixed profile batch is not supported"],
+                }
+                for receipt_type in receipt_types
+            ],
+        }
+
+    if validate_glimps_receipt is None:
+        return {
+            "ok": False,
+            "profile": "glimps",
+            "errors": ["GLIMPS validator is unavailable"],
+            "results": [],
+        }
+
+    results = []
+    for receipt in receipts:
+        receipt_type = receipt.get("receipt_type", "<missing>")
+        if receipt_type not in GLIMPS_RECEIPT_TYPES:
+            results.append({
+                "ok": False,
+                "receipt_type": receipt_type,
+                "profile": "glimps",
+                "errors": [f"unknown GLIMPS receipt_type: {receipt_type!r}"],
+            })
+            continue
+
+        result = validate_glimps_receipt(receipt)
+        results.append({
+            "ok": result.passed,
+            "receipt_type": result.receipt_type,
+            "profile": "glimps",
+            "errors": result.errors,
+        })
+
+    ok = all(result["ok"] for result in results)
+    if len(results) == 1:
+        return results[0]
+
+    return {
+        "ok": ok,
+        "profile": "glimps",
+        "receipt_count": len(results),
+        "errors": [error for result in results for error in result["errors"]],
+        "results": results,
+    }
+
+
 def load_receipts(path: Path) -> list[dict]:
     """Load receipts from a file or directory."""
     receipts = []
@@ -519,6 +621,11 @@ def main():
         action="store_true",
         help="Verbose output",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print structured JSON report to stdout",
+    )
 
     args = parser.parse_args()
 
@@ -533,8 +640,30 @@ def main():
         print("Warning: No receipts found")
         receipts = []
 
+    profile_report = dispatch_profile_validation(receipts)
+    if profile_report is not None:
+        if args.output:
+            with open(args.output, "w") as f:
+                json.dump(profile_report, f, indent=2)
+        if args.json:
+            print(json.dumps(profile_report, indent=2))
+        else:
+            status = "PASS" if profile_report["ok"] else "FAIL"
+            print(f"Assay profile validation: [{status}]")
+            if "receipt_type" in profile_report:
+                print(f"Receipt type: {profile_report['receipt_type']}")
+            print(f"Profile: {profile_report['profile']}")
+            for error in profile_report.get("errors", []):
+                print(f"  {error}")
+            if args.output:
+                print(f"Report saved to: {args.output}")
+        sys.exit(0 if profile_report["ok"] else 1)
+
     # Run validation
     report = validate_receipts(receipts)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+        sys.exit(0 if report.overall_pass else 1)
 
     # Print summary
     print("=" * 60)

--- a/scripts/assay_validate.py
+++ b/scripts/assay_validate.py
@@ -41,12 +41,10 @@ except ImportError:
 
 
 try:
-    from glimps_validate import SCHEMA_BY_RECEIPT_TYPE as GLIMPS_RECEIPT_TYPES
     from glimps_validate import validate_glimps_receipt
 except ImportError:
     # Keep the gateway conformance validator usable even when profile validators
     # are not installed on a copied script path.
-    GLIMPS_RECEIPT_TYPES = {}
     validate_glimps_receipt = None
 
 
@@ -478,6 +476,27 @@ def is_glimps_receipt_type(receipt_type: object) -> bool:
     return isinstance(receipt_type, str) and receipt_type.startswith("glimps.")
 
 
+def load_profile_registry(repo_root: Optional[Path] = None) -> dict:
+    """Load Assay profile registry metadata."""
+    base = repo_root or Path(__file__).resolve().parents[1]
+    registry_path = base / "profiles" / "registry.json"
+    if not registry_path.exists():
+        return {"profiles": {}}
+    with open(registry_path) as f:
+        return json.load(f)
+
+
+def registered_glimps_receipt_types(repo_root: Optional[Path] = None) -> set[str]:
+    """Return GLIMPS receipt types registered with Assay."""
+    registry = load_profile_registry(repo_root)
+    return set(
+        registry.get("profiles", {})
+        .get("glimps", {})
+        .get("receipt_types", {})
+        .keys()
+    )
+
+
 def dispatch_profile_validation(receipts: list[dict]) -> Optional[dict]:
     """Dispatch profile-owned receipts to their profile validator.
 
@@ -532,15 +551,16 @@ def dispatch_profile_validation(receipts: list[dict]) -> Optional[dict]:
             "results": [],
         }
 
+    registered_receipt_types = registered_glimps_receipt_types()
     results = []
     for receipt in receipts:
         receipt_type = receipt.get("receipt_type", "<missing>")
-        if receipt_type not in GLIMPS_RECEIPT_TYPES:
+        if receipt_type not in registered_receipt_types:
             results.append({
                 "ok": False,
                 "receipt_type": receipt_type,
                 "profile": "glimps",
-                "errors": [f"unknown GLIMPS receipt_type: {receipt_type!r}"],
+                "errors": [f"unregistered GLIMPS receipt_type: {receipt_type!r}"],
             })
             continue
 

--- a/scripts/glimps_validate.py
+++ b/scripts/glimps_validate.py
@@ -119,6 +119,11 @@ def _validate_schema_fragment(
     if "enum" in schema and value not in schema["enum"]:
         errors.append(f"{path}: value {value!r} not in enum {schema['enum']!r}")
 
+    if isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        if minimum is not None and value < minimum:
+            errors.append(f"{path}: value {value!r} below minimum {minimum}")
+
     if isinstance(value, str):
         min_length = schema.get("minLength")
         if min_length is not None and len(value) < min_length:

--- a/scripts/glimps_validate.py
+++ b/scripts/glimps_validate.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Validate GLIMPS profile receipts.
+
+This is a lightweight profile validator for:
+- glimps.birth/v0
+- glimps.emission_census/v0
+- glimps.wound/v0
+
+It intentionally validates profile shape and GLIMPS authority boundaries only.
+It does not grant runtime authority, integrate Guardian, or mutate memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_BY_RECEIPT_TYPE = {
+    "glimps.birth/v0": "glimpse_birth_receipt.v0.json",
+    "glimps.emission_census/v0": "glimpse_emission_census.v0.json",
+    "glimps.wound/v0": "glimpse_wound_receipt.v0.json",
+}
+
+BEAUTY_TERMS = {
+    "aesthetic",
+    "beautiful",
+    "beauty",
+    "elegant",
+    "elegance",
+    "metaphor",
+    "metaphorical",
+    "analogy",
+    "analogical",
+}
+
+CONCRETE_WOUND_TERMS = {
+    "boundary",
+    "case",
+    "check",
+    "compute",
+    "counterexample",
+    "fixture",
+    "measure",
+    "observe",
+    "probe",
+    "receipt",
+    "replay",
+    "test",
+    "trace",
+    "verify",
+}
+
+
+@dataclass
+class GlimpsValidationResult:
+    receipt_type: str
+    passed: bool
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_type": self.receipt_type,
+            "passed": self.passed,
+            "errors": self.errors,
+        }
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def schema_dir(root: Path | None = None) -> Path:
+    base = root or repo_root()
+    return base / "profiles" / "glimps" / "schema"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def load_schema(receipt_type: str, root: Path | None = None) -> dict[str, Any]:
+    schema_name = SCHEMA_BY_RECEIPT_TYPE.get(receipt_type)
+    if schema_name is None:
+        raise ValueError(f"unknown GLIMPS receipt_type: {receipt_type!r}")
+    return load_json(schema_dir(root) / schema_name)
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    return True
+
+
+def _validate_schema_fragment(
+    value: Any,
+    schema: dict[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    expected_type = schema.get("type")
+    if expected_type and not _type_matches(value, expected_type):
+        errors.append(f"{path}: expected {expected_type}")
+        return
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: value {value!r} not in enum {schema['enum']!r}")
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if min_length is not None and len(value) < min_length:
+            errors.append(f"{path}: string shorter than minLength {min_length}")
+        pattern = schema.get("pattern")
+        if pattern and not re.match(pattern, value):
+            errors.append(f"{path}: does not match pattern {pattern!r}")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            errors.append(f"{path}: array shorter than minItems {min_items}")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                _validate_schema_fragment(item, item_schema, f"{path}[{index}]", errors)
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        properties = schema.get("properties", {})
+        for key in required:
+            if key not in value:
+                errors.append(f"{path}.{key}: missing required field")
+        if schema.get("additionalProperties") is False:
+            for key in value:
+                if key not in properties:
+                    errors.append(f"{path}.{key}: additional property not allowed")
+        for key, child_schema in properties.items():
+            if key in value:
+                _validate_schema_fragment(value[key], child_schema, f"{path}.{key}", errors)
+
+
+def validate_required_schema(receipt: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _validate_schema_fragment(receipt, schema, "$", errors)
+    return errors
+
+
+def _nested(receipt: dict[str, Any], path: str) -> Any:
+    value: Any = receipt
+    for part in path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _is_non_empty(value: Any) -> bool:
+    return value not in (None, "", [])
+
+
+def _text_tokens(value: Any) -> set[str]:
+    text = json.dumps(value).lower().replace("_", " ")
+    return set(re.findall(r"[a-z_]+", text))
+
+
+def _value_text_tokens(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return set(re.findall(r"[a-z_]+", value.lower().replace("_", " ")))
+    if isinstance(value, list):
+        tokens: set[str] = set()
+        for item in value:
+            tokens |= _value_text_tokens(item)
+        return tokens
+    if isinstance(value, dict):
+        tokens: set[str] = set()
+        for item in value.values():
+            tokens |= _value_text_tokens(item)
+        return tokens
+    return set()
+
+
+def _semantic_birth_errors(receipt: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    required_non_empty = [
+        "pressure_statement",
+        "lens",
+        "lens.makes_visible",
+        "lens.hides",
+        "lens_debt.counter_lens",
+        "rivals",
+        "first_wound",
+    ]
+    for path in required_non_empty:
+        if not _is_non_empty(_nested(receipt, path)):
+            errors.append(f"{path}: required and non-empty")
+
+    if receipt.get("initial_authority") != "speculative":
+        errors.append("initial_authority: must be speculative")
+
+    permissions = receipt.get("permissions", {})
+    required_permission_values = {
+        "can_govern_execution": False,
+        "can_modify_policy": False,
+        "can_allocate_execution_budget": False,
+        "can_change_default_route": False,
+        "can_raise_confidence_without_receipts": False,
+        "requires_receipts_for_promotion": True,
+    }
+    for key, expected in required_permission_values.items():
+        if permissions.get(key) is not expected:
+            errors.append(f"permissions.{key}: must be {expected}")
+
+    if permissions.get("can_prioritize_search") is True and permissions.get(
+        "can_allocate_execution_budget"
+    ) is not False:
+        errors.append("permissions: search priority must not imply budget allocation")
+
+    negative_duties = receipt.get("negative_duties", {})
+    for key in [
+        "must_not_raise_confidence",
+        "must_not_suppress_rivals",
+        "must_not_mutate_memory",
+        "must_not_modify_policy",
+        "must_not_claim_exhaustive_search",
+        "must_not_present_beauty_as_evidence",
+    ]:
+        if negative_duties.get(key) is not True:
+            errors.append(f"negative_duties.{key}: must be true")
+
+    if receipt.get("confidence") == "high" and receipt.get("fertility") == "high":
+        errors.append("confidence/fertility: high fertility cannot raise confidence")
+
+    tokens = _text_tokens(
+        {
+            "source_pressure": receipt.get("source_pressure"),
+            "imagination_type": receipt.get("imagination_type"),
+            "lens": receipt.get("lens"),
+            "candidate": receipt.get("candidate_claim_or_frame"),
+            "attention_request": receipt.get("attention_request"),
+        }
+    )
+    if tokens & BEAUTY_TERMS and receipt.get("confidence") != "low":
+        errors.append("beauty/analogy: may point, but may not raise confidence")
+
+    imagination_type = set(receipt.get("imagination_type", []))
+    if "analogical" in imagination_type:
+        wound_tokens = _value_text_tokens(receipt.get("first_wound", {}))
+        if not (wound_tokens & CONCRETE_WOUND_TERMS):
+            errors.append("first_wound: analogical candidates require a concrete non-analogical probe")
+
+    for ghost in receipt.get("related_ghosts", []):
+        if not ghost.get("new_receipts"):
+            errors.append("related_ghosts: ghost seeds require new receipts")
+        if permissions.get("can_govern_execution") is not False:
+            errors.append("related_ghosts: ghosts may seed, but never govern")
+
+    if receipt.get("truth_track") not in {"truth", "usefulness", "representation", "obstruction", "taxonomy"}:
+        errors.append("truth_track: unknown track")
+
+    return errors
+
+
+def _semantic_census_errors(receipt: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    candidates_generated = receipt.get("candidates_generated")
+    candidates_with_rivals = receipt.get("candidates_with_rivals")
+    candidates_with_first_wounds = receipt.get("candidates_with_first_wounds")
+
+    if isinstance(candidates_generated, int):
+        if isinstance(candidates_with_rivals, int) and candidates_with_rivals > candidates_generated:
+            errors.append("candidates_with_rivals: cannot exceed candidates_generated")
+        if (
+            isinstance(candidates_with_first_wounds, int)
+            and candidates_with_first_wounds > candidates_generated
+        ):
+            errors.append("candidates_with_first_wounds: cannot exceed candidates_generated")
+        if (
+            isinstance(candidates_with_first_wounds, int)
+            and candidates_generated > candidates_with_first_wounds
+            and receipt.get("unwounded_candidate_warning") is not True
+        ):
+            errors.append("unwounded_candidate_warning: must be true when candidates lack first wounds")
+        if (
+            isinstance(candidates_with_rivals, int)
+            and candidates_generated > candidates_with_rivals
+            and receipt.get("rival_suppression_warning") is not True
+        ):
+            errors.append("rival_suppression_warning: must be true when candidates lack rivals")
+
+    for key in ["frame_monoculture_warning", "attention_capture_warning"]:
+        if not isinstance(receipt.get(key), bool):
+            errors.append(f"{key}: must be an explicit boolean")
+
+    if receipt.get("pressures_detected", 0) > 0 and "pressures_without_candidates" not in receipt:
+        errors.append("pressures_without_candidates: must not be silently omitted")
+
+    return errors
+
+
+def _semantic_wound_errors(receipt: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for key in ["glimpse_id", "candidate_id", "wound_id", "expected_result", "observed_result"]:
+        if not _is_non_empty(receipt.get(key)):
+            errors.append(f"{key}: required and non-empty")
+
+    for forbidden in ["authority", "authority_granted", "guardian_decision"]:
+        if forbidden in receipt:
+            errors.append(f"{forbidden}: wound receipts record probes only and grant no authority")
+
+    return errors
+
+
+def validate_glimps_receipt(
+    receipt: dict[str, Any],
+    root: Path | None = None,
+) -> GlimpsValidationResult:
+    receipt_type = receipt.get("receipt_type", "<missing>")
+    if receipt_type not in SCHEMA_BY_RECEIPT_TYPE:
+        return GlimpsValidationResult(
+            receipt_type=receipt_type,
+            passed=False,
+            errors=[f"unknown GLIMPS receipt_type: {receipt_type!r}"],
+        )
+
+    schema = load_schema(receipt_type, root)
+    errors = validate_required_schema(receipt, schema)
+
+    if receipt_type == "glimps.birth/v0":
+        errors.extend(_semantic_birth_errors(receipt))
+    elif receipt_type == "glimps.emission_census/v0":
+        errors.extend(_semantic_census_errors(receipt))
+    elif receipt_type == "glimps.wound/v0":
+        errors.extend(_semantic_wound_errors(receipt))
+
+    return GlimpsValidationResult(
+        receipt_type=receipt_type,
+        passed=not errors,
+        errors=errors,
+    )
+
+
+def load_receipts(path: Path) -> list[dict[str, Any]]:
+    if path.is_file():
+        data = load_json(path)
+        return data if isinstance(data, list) else [data]
+
+    receipts = []
+    for file in sorted(path.glob("*.json")):
+        data = load_json(file)
+        if isinstance(data, list):
+            receipts.extend(data)
+        else:
+            receipts.append(data)
+    return receipts
+
+
+def validate_path(path: Path, root: Path | None = None) -> list[GlimpsValidationResult]:
+    return [validate_glimps_receipt(receipt, root) for receipt in load_receipts(path)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate GLIMPS profile receipts")
+    parser.add_argument("receipts", type=Path, help="GLIMPS receipt file or directory")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    args = parser.parse_args()
+
+    if not args.receipts.exists():
+        print(f"Error: {args.receipts} does not exist")
+        return 1
+
+    results = validate_path(args.receipts)
+    overall_pass = all(result.passed for result in results)
+
+    if args.json:
+        print(json.dumps({"passed": overall_pass, "results": [r.to_dict() for r in results]}, indent=2))
+    else:
+        status = "PASS" if overall_pass else "FAIL"
+        print(f"GLIMPS profile validation: [{status}]")
+        for result in results:
+            item_status = "PASS" if result.passed else "FAIL"
+            print(f"  [{item_status}] {result.receipt_type}")
+            for error in result.errors:
+                print(f"         {error}")
+
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_assay_validate_glimps_dispatch.py
+++ b/tests/test_assay_validate_glimps_dispatch.py
@@ -77,7 +77,7 @@ def test_general_dispatcher_rejects_unknown_glimps_receipt_type():
     report = dispatch_profile_validation([receipt])
     assert report["ok"] is False
     assert report["receipt_type"] == "glimps.unknown/v0"
-    assert any("unknown GLIMPS receipt_type" in error for error in report["errors"])
+    assert any("unregistered GLIMPS receipt_type" in error for error in report["errors"])
 
 
 def test_general_dispatcher_rejects_non_string_receipt_type():

--- a/tests/test_assay_validate_glimps_dispatch.py
+++ b/tests/test_assay_validate_glimps_dispatch.py
@@ -1,0 +1,190 @@
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from assay_validate import dispatch_profile_validation  # noqa: E402
+
+
+EXAMPLES = ROOT / "profiles" / "glimps" / "examples"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def birth_example():
+    return load_json(EXAMPLES / "agent_failure_birth_receipt.json")
+
+
+def census_example():
+    return load_json(EXAMPLES / "emission_census.json")
+
+
+def wound_example():
+    return load_json(EXAMPLES / "wound_receipt.json")
+
+
+def run_json_command(*args):
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, json.loads(result.stdout)
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value))
+
+
+def test_general_dispatcher_validates_valid_glimps_birth_receipt():
+    report = dispatch_profile_validation([birth_example()])
+    assert report == {
+        "ok": True,
+        "receipt_type": "glimps.birth/v0",
+        "profile": "glimps",
+        "errors": [],
+    }
+
+
+def test_general_dispatcher_validates_valid_glimps_emission_census():
+    report = dispatch_profile_validation([census_example()])
+    assert report["ok"] is True
+    assert report["receipt_type"] == "glimps.emission_census/v0"
+    assert report["profile"] == "glimps"
+    assert report["errors"] == []
+
+
+def test_general_dispatcher_validates_valid_glimps_wound_receipt():
+    report = dispatch_profile_validation([wound_example()])
+    assert report["ok"] is True
+    assert report["receipt_type"] == "glimps.wound/v0"
+    assert report["profile"] == "glimps"
+    assert report["errors"] == []
+
+
+def test_general_dispatcher_rejects_unknown_glimps_receipt_type():
+    receipt = copy.deepcopy(birth_example())
+    receipt["receipt_type"] = "glimps.unknown/v0"
+    report = dispatch_profile_validation([receipt])
+    assert report["ok"] is False
+    assert report["receipt_type"] == "glimps.unknown/v0"
+    assert any("unknown GLIMPS receipt_type" in error for error in report["errors"])
+
+
+def test_general_dispatcher_rejects_non_string_receipt_type():
+    report = dispatch_profile_validation([{"receipt_type": None}])
+    assert report["ok"] is False
+    assert report["receipt_type"] is None
+    assert report["profile"] == "unknown"
+    assert report["errors"] == ["receipt_type: must be a string"]
+
+
+def test_general_dispatcher_preserves_glimps_semantic_errors():
+    receipt = copy.deepcopy(birth_example())
+    receipt["permissions"]["can_govern_execution"] = True
+    report = dispatch_profile_validation([receipt])
+    assert report["ok"] is False
+    assert any("permissions.can_govern_execution" in error for error in report["errors"])
+
+
+def test_general_dispatcher_enforces_glimps_schema_minimums():
+    receipt = copy.deepcopy(census_example())
+    for key in [
+        "pressures_detected",
+        "glimpses_generated",
+        "lenses_generated",
+        "candidates_generated",
+        "candidates_with_rivals",
+        "candidates_with_first_wounds",
+    ]:
+        receipt[key] = -1
+    report = dispatch_profile_validation([receipt])
+    assert report["ok"] is False
+    assert any("below minimum 0" in error for error in report["errors"])
+
+
+def test_assay_validate_cli_dispatches_glimps_birth_json():
+    result, report = run_json_command(
+        "scripts/assay_validate.py",
+        "profiles/glimps/examples/agent_failure_birth_receipt.json",
+        "--json",
+    )
+    assert result.returncode == 0
+    assert report == {
+        "ok": True,
+        "receipt_type": "glimps.birth/v0",
+        "profile": "glimps",
+        "errors": [],
+    }
+
+
+def test_assay_validate_cli_dispatches_glimps_directory_json():
+    result, report = run_json_command(
+        "scripts/assay_validate.py",
+        "profiles/glimps/examples",
+        "--json",
+    )
+    assert result.returncode == 0
+    assert report["ok"] is True
+    assert report["profile"] == "glimps"
+    assert report["receipt_count"] == 5
+    assert {item["receipt_type"] for item in report["results"]} == {
+        "glimps.birth/v0",
+        "glimps.emission_census/v0",
+        "glimps.wound/v0",
+    }
+
+
+def test_assay_validate_cli_rejects_non_string_receipt_type_json(tmp_path):
+    malformed = tmp_path / "malformed.json"
+    write_json(malformed, {"receipt_type": None})
+    result, report = run_json_command("scripts/assay_validate.py", str(malformed), "--json")
+    assert result.returncode == 1
+    assert report["ok"] is False
+    assert report["receipt_type"] is None
+    assert report["errors"] == ["receipt_type: must be a string"]
+
+
+def test_assay_validate_cli_writes_profile_output_report(tmp_path):
+    output = tmp_path / "glimps-report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/assay_validate.py",
+            "profiles/glimps/examples/agent_failure_birth_receipt.json",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    report = load_json(output)
+    assert report == {
+        "ok": True,
+        "receipt_type": "glimps.birth/v0",
+        "profile": "glimps",
+        "errors": [],
+    }
+
+
+def test_standalone_glimps_validator_still_works():
+    result, report = run_json_command(
+        "scripts/glimps_validate.py",
+        "profiles/glimps/examples/agent_failure_birth_receipt.json",
+        "--json",
+    )
+    assert result.returncode == 0
+    assert report["passed"] is True
+    assert report["results"][0]["receipt_type"] == "glimps.birth/v0"

--- a/tests/test_glimps_birth_receipt.py
+++ b/tests/test_glimps_birth_receipt.py
@@ -1,0 +1,112 @@
+import copy
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GLIMPS = ROOT / "profiles" / "glimps"
+EXAMPLES = GLIMPS / "examples"
+SCHEMAS = GLIMPS / "schema"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def birth_example(name="agent_failure_birth_receipt.json"):
+    return load_json(EXAMPLES / name)
+
+
+def birth_schema():
+    return load_json(SCHEMAS / "glimpse_birth_receipt.v0.json")
+
+
+def assert_required_path(document, path):
+    value = document
+    for part in path.split("."):
+        assert part in value, f"missing {path}"
+        value = value[part]
+    assert value not in ("", [], None), f"empty {path}"
+
+
+def test_birth_receipt_requires_pressure_statement():
+    schema = birth_schema()
+    example = birth_example()
+    assert "pressure_statement" in schema["required"]
+    assert_required_path(example, "pressure_statement")
+
+
+def test_birth_receipt_requires_lens():
+    schema = birth_schema()
+    example = birth_example()
+    assert "lens" in schema["required"]
+    assert_required_path(example, "lens.name")
+
+
+def test_lens_records_makes_visible_and_hides():
+    example = birth_example()
+    assert_required_path(example, "lens.makes_visible")
+    assert_required_path(example, "lens.hides")
+
+
+def test_lens_debt_requires_counter_lens():
+    schema = birth_schema()
+    example = birth_example()
+    assert "counter_lens" in schema["properties"]["lens_debt"]["required"]
+    assert_required_path(example, "lens_debt.counter_lens")
+
+
+def test_birth_receipt_requires_at_least_one_rival():
+    schema = birth_schema()
+    example = birth_example()
+    assert "rivals" in schema["required"]
+    assert len(example["rivals"]) >= 1
+
+
+def test_birth_receipt_requires_first_wound():
+    schema = birth_schema()
+    example = birth_example()
+    assert "first_wound" in schema["required"]
+    assert_required_path(example, "first_wound.smallest_test")
+    assert_required_path(example, "first_wound.what_would_hurt")
+    assert_required_path(example, "first_wound.what_it_forbids")
+
+
+def test_initial_authority_must_be_speculative():
+    schema = birth_schema()
+    example = birth_example()
+    assert schema["properties"]["initial_authority"]["enum"] == ["speculative"]
+    assert example["initial_authority"] == "speculative"
+
+
+def test_truth_track_and_usefulness_track_are_distinct():
+    schema = birth_schema()
+    tracks = schema["properties"]["truth_track"]["enum"]
+    assert "truth" in tracks
+    assert "usefulness" in tracks
+    assert birth_example("math_birth_receipt.json")["truth_track"] != birth_example(
+        "ghost_reactivation_birth_receipt.json"
+    )["truth_track"]
+
+
+def test_glimpse_packet_can_promote_to_claim_packet_only_if_woundable():
+    example = birth_example()
+    woundable_fields = [
+        "pressure_statement",
+        "lens.hides",
+        "rivals",
+        "first_wound.smallest_test",
+        "permissions",
+        "promotion_requirements",
+    ]
+    for path in woundable_fields:
+        assert_required_path(example, path)
+    assert example["initial_authority"] == "speculative"
+
+
+def test_analogy_candidate_requires_non_analogical_wound():
+    candidate = copy.deepcopy(birth_example("math_birth_receipt.json"))
+    candidate["imagination_type"].append("analogical")
+    wound_text = " ".join(candidate["first_wound"].values()).lower()
+    assert "analogy" not in wound_text
+    assert "compute" in wound_text or "boundary" in wound_text

--- a/tests/test_glimps_emission_census.py
+++ b/tests/test_glimps_emission_census.py
@@ -1,0 +1,78 @@
+import copy
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "profiles" / "glimps" / "examples"
+SCHEMAS = ROOT / "profiles" / "glimps" / "schema"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def census_example():
+    return load_json(EXAMPLES / "emission_census.json")
+
+
+def census_schema():
+    return load_json(SCHEMAS / "glimpse_emission_census.v0.json")
+
+
+def test_emission_census_schema_requires_birth_side_counts():
+    schema = census_schema()
+    for field in [
+        "pressures_detected",
+        "glimpses_generated",
+        "lenses_generated",
+        "candidates_generated",
+        "candidates_with_rivals",
+        "candidates_with_first_wounds",
+    ]:
+        assert field in schema["required"]
+
+
+def test_emission_census_detects_missing_first_wounds():
+    census = copy.deepcopy(census_example())
+    census["candidates_with_first_wounds"] = census["candidates_generated"] - 1
+    census["unwounded_candidate_warning"] = (
+        census["candidates_with_first_wounds"] < census["candidates_generated"]
+    )
+    assert census["unwounded_candidate_warning"] is True
+
+
+def test_emission_census_flags_frame_monoculture():
+    census = copy.deepcopy(census_example())
+    census["lenses_generated"] = 1
+    census["candidates_generated"] = 5
+    census["frame_monoculture_warning"] = (
+        census["lenses_generated"] <= 1 and census["candidates_generated"] > 1
+    )
+    assert census["frame_monoculture_warning"] is True
+
+
+def test_emission_census_flags_attention_capture():
+    census = copy.deepcopy(census_example())
+    census["glimpses_generated"] = 9
+    high_priority_requests = 9
+    census["attention_capture_warning"] = high_priority_requests == census["glimpses_generated"]
+    assert census["attention_capture_warning"] is True
+
+
+def test_emission_census_flags_rival_suppression():
+    census = copy.deepcopy(census_example())
+    census["candidates_with_rivals"] = census["candidates_generated"] - 1
+    census["rival_suppression_warning"] = (
+        census["candidates_with_rivals"] < census["candidates_generated"]
+    )
+    assert census["rival_suppression_warning"] is True
+
+
+def test_emission_census_flags_fertility_confidence_confusion():
+    census = copy.deepcopy(census_example())
+    high_fertility_candidates_counted_as_high_confidence = 1
+    census["fertility_confidence_confusion_warning"] = (
+        high_fertility_candidates_counted_as_high_confidence > 0
+    )
+    assert census["fertility_confidence_confusion_warning"] is True

--- a/tests/test_glimps_permissions.py
+++ b/tests/test_glimps_permissions.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "profiles" / "glimps" / "examples"
+SCHEMAS = ROOT / "profiles" / "glimps" / "schema"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def birth_example(name="agent_failure_birth_receipt.json"):
+    return load_json(EXAMPLES / name)
+
+
+def birth_schema():
+    return load_json(SCHEMAS / "glimpse_birth_receipt.v0.json")
+
+
+def test_glimps_candidate_cannot_govern_execution():
+    example = birth_example()
+    assert example["permissions"]["can_govern_execution"] is False
+
+
+def test_glimps_candidate_cannot_modify_policy():
+    example = birth_example()
+    assert example["permissions"]["can_modify_policy"] is False
+    assert example["negative_duties"]["must_not_modify_policy"] is True
+
+
+def test_glimps_can_prioritize_search_but_not_allocate_budget():
+    example = birth_example()
+    assert example["permissions"]["can_prioritize_search"] is True
+    assert example["permissions"]["can_allocate_execution_budget"] is False
+    assert example["attention_request"]["requires_gate"] is True
+
+
+def test_glimps_cannot_change_default_route():
+    example = birth_example()
+    assert example["permissions"]["can_change_default_route"] is False
+
+
+def test_fertility_cannot_raise_confidence():
+    example = birth_example()
+    assert example["fertility"] == "high"
+    assert example["confidence"] == "low"
+    assert example["permissions"]["can_raise_confidence_without_receipts"] is False
+    assert example["negative_duties"]["must_not_raise_confidence"] is True
+
+
+def test_ai_intuition_cannot_raise_confidence_without_receipts():
+    schema = birth_schema()
+    proposer_kind = schema["properties"]["proposer"]["properties"]["kind"]["enum"]
+    assert "ai" in proposer_kind
+    permission = schema["properties"]["permissions"]["properties"][
+        "can_raise_confidence_without_receipts"
+    ]
+    assert permission["enum"] == [False]
+
+
+def test_beauty_may_point_but_not_testify():
+    example = birth_example("math_birth_receipt.json")
+    assert "beautiful_near_miss" in example["source_pressure"]
+    assert example["attention_request"]["requested"] is True
+    assert example["permissions"]["can_raise_confidence_without_receipts"] is False
+    assert example["negative_duties"]["must_not_present_beauty_as_evidence"] is True
+
+
+def test_glimpse_negative_duties_present():
+    schema = birth_schema()
+    example = birth_example()
+    required = set(schema["properties"]["negative_duties"]["required"])
+    assert required == set(example["negative_duties"])
+    assert all(example["negative_duties"].values())
+
+
+def test_ghost_seed_cannot_reactivate_without_new_receipts():
+    example = birth_example("ghost_reactivation_birth_receipt.json")
+    assert example["permissions"]["can_govern_execution"] is False
+    assert example["related_ghosts"]
+    for ghost in example["related_ghosts"]:
+        assert ghost["new_receipts"], "ghost reactivation requires new receipts"

--- a/tests/test_glimps_validator.py
+++ b/tests/test_glimps_validator.py
@@ -119,6 +119,20 @@ def test_emission_census_inconsistent_counts_fail():
     assert_invalid(receipt, "candidates_with_rivals")
 
 
+def test_emission_census_negative_counts_fail_schema_minimums():
+    receipt = copy.deepcopy(census_example())
+    for key in [
+        "pressures_detected",
+        "glimpses_generated",
+        "lenses_generated",
+        "candidates_generated",
+        "candidates_with_rivals",
+        "candidates_with_first_wounds",
+    ]:
+        receipt[key] = -1
+    assert_invalid(receipt, "below minimum 0")
+
+
 def test_emission_census_missing_first_wounds_warning_is_enforced():
     receipt = copy.deepcopy(census_example())
     receipt["candidates_with_first_wounds"] = receipt["candidates_generated"] - 1

--- a/tests/test_glimps_validator.py
+++ b/tests/test_glimps_validator.py
@@ -1,0 +1,139 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from glimps_validate import validate_glimps_receipt  # noqa: E402
+
+
+EXAMPLES = ROOT / "profiles" / "glimps" / "examples"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def birth_example(name="agent_failure_birth_receipt.json"):
+    return load_json(EXAMPLES / name)
+
+
+def census_example():
+    return load_json(EXAMPLES / "emission_census.json")
+
+
+def wound_example():
+    return load_json(EXAMPLES / "wound_receipt.json")
+
+
+def assert_invalid(receipt, expected_fragment):
+    result = validate_glimps_receipt(receipt, ROOT)
+    assert result.passed is False
+    assert any(expected_fragment in error for error in result.errors), result.errors
+
+
+def test_valid_birth_example_passes_validator():
+    result = validate_glimps_receipt(birth_example(), ROOT)
+    assert result.passed is True
+    assert result.errors == []
+
+
+def test_valid_emission_census_example_passes_validator():
+    result = validate_glimps_receipt(census_example(), ROOT)
+    assert result.passed is True
+    assert result.errors == []
+
+
+def test_valid_wound_example_passes_validator():
+    result = validate_glimps_receipt(wound_example(), ROOT)
+    assert result.passed is True
+    assert result.errors == []
+
+
+def test_invalid_receipt_type_fails():
+    receipt = copy.deepcopy(birth_example())
+    receipt["receipt_type"] = "glimps.claim/v0"
+    assert_invalid(receipt, "unknown GLIMPS receipt_type")
+
+
+def test_authority_leakage_fails():
+    receipt = copy.deepcopy(birth_example())
+    receipt["permissions"]["can_govern_execution"] = True
+    assert_invalid(receipt, "permissions.can_govern_execution")
+
+
+def test_missing_pressure_statement_fails():
+    receipt = copy.deepcopy(birth_example())
+    del receipt["pressure_statement"]
+    assert_invalid(receipt, "pressure_statement")
+
+
+def test_missing_rival_fails():
+    receipt = copy.deepcopy(birth_example())
+    receipt["rivals"] = []
+    assert_invalid(receipt, "rivals")
+
+
+def test_missing_first_wound_fails():
+    receipt = copy.deepcopy(birth_example())
+    del receipt["first_wound"]
+    assert_invalid(receipt, "first_wound")
+
+
+def test_confidence_raised_without_receipts_fails():
+    receipt = copy.deepcopy(birth_example())
+    receipt["confidence"] = "high"
+    receipt["fertility"] = "high"
+    assert_invalid(receipt, "high fertility cannot raise confidence")
+
+
+def test_beauty_may_point_but_not_testify():
+    receipt = copy.deepcopy(birth_example("math_birth_receipt.json"))
+    receipt["confidence"] = "medium"
+    assert_invalid(receipt, "beauty/analogy")
+
+
+def test_analogical_candidate_requires_non_analogical_wound():
+    receipt = copy.deepcopy(birth_example("math_birth_receipt.json"))
+    receipt["imagination_type"] = ["analogical"]
+    receipt["first_wound"] = {
+        "smallest_test": "Compare the analogy to another analogy.",
+        "what_would_hurt": "The metaphor feels weaker.",
+        "what_it_forbids": "A less elegant metaphor."
+    }
+    assert_invalid(receipt, "analogical candidates require")
+
+
+def test_wound_receipt_without_glimpse_id_fails():
+    receipt = copy.deepcopy(wound_example())
+    del receipt["glimpse_id"]
+    assert_invalid(receipt, "glimpse_id")
+
+
+def test_emission_census_inconsistent_counts_fail():
+    receipt = copy.deepcopy(census_example())
+    receipt["candidates_with_rivals"] = receipt["candidates_generated"] + 1
+    assert_invalid(receipt, "candidates_with_rivals")
+
+
+def test_emission_census_missing_first_wounds_warning_is_enforced():
+    receipt = copy.deepcopy(census_example())
+    receipt["candidates_with_first_wounds"] = receipt["candidates_generated"] - 1
+    receipt["unwounded_candidate_warning"] = False
+    assert_invalid(receipt, "unwounded_candidate_warning")
+
+
+def test_rival_suppression_warning_is_enforced():
+    receipt = copy.deepcopy(census_example())
+    receipt["candidates_with_rivals"] = receipt["candidates_generated"] - 1
+    receipt["rival_suppression_warning"] = False
+    assert_invalid(receipt, "rival_suppression_warning")
+
+
+def test_wound_receipt_grants_no_authority():
+    receipt = copy.deepcopy(wound_example())
+    receipt["authority_granted"] = True
+    assert_invalid(receipt, "authority_granted")

--- a/tests/test_glimps_wound_receipt.py
+++ b/tests/test_glimps_wound_receipt.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "profiles" / "glimps" / "examples"
+SCHEMAS = ROOT / "profiles" / "glimps" / "schema"
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def birth_example():
+    return load_json(EXAMPLES / "agent_failure_birth_receipt.json")
+
+
+def wound_example():
+    return load_json(EXAMPLES / "wound_receipt.json")
+
+
+def wound_schema():
+    return load_json(SCHEMAS / "glimpse_wound_receipt.v0.json")
+
+
+def test_wound_receipt_schema_has_expected_routes():
+    routes = wound_schema()["properties"]["next_route"]["enum"]
+    assert routes == [
+        "promote_to_claim_packet",
+        "revise",
+        "archive_as_ghost",
+        "run_more_wounds",
+    ]
+
+
+def test_wound_receipt_links_to_birth_receipt():
+    birth = birth_example()
+    wound = wound_example()
+    assert wound["glimpse_id"] == birth["glimpse_id"]
+
+
+def test_wound_receipt_records_probe_and_result():
+    wound = wound_example()
+    assert wound["receipt_type"] == "glimps.wound/v0"
+    assert wound["probe_type"] in wound_schema()["properties"]["probe_type"]["enum"]
+    assert wound["expected_result"]
+    assert wound["observed_result"]
+    assert wound["wound_result"] in ["survived", "weakened", "killed", "inconclusive"]
+
+
+def test_wound_receipt_keeps_promotion_explicit():
+    wound = wound_example()
+    assert wound["next_route"] != "promote_to_claim_packet"
+    assert wound["next_route"] in wound_schema()["properties"]["next_route"]["enum"]

--- a/tests/test_profile_registry.py
+++ b/tests/test_profile_registry.py
@@ -1,0 +1,130 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from assay_validate import dispatch_profile_validation, registered_glimps_receipt_types  # noqa: E402
+
+
+REGISTRY_PATH = ROOT / "profiles" / "registry.json"
+EXPECTED_GLIMPS_RECEIPT_TYPES = {
+    "glimps.birth/v0",
+    "glimps.emission_census/v0",
+    "glimps.wound/v0",
+}
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def registry():
+    return load_json(REGISTRY_PATH)
+
+
+def glimps_profile():
+    return registry()["profiles"]["glimps"]
+
+
+def run_json_command(*args):
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, json.loads(result.stdout)
+
+
+def test_registry_file_parses_as_json():
+    data = registry()
+    assert "profiles" in data
+    assert "glimps" in data["profiles"]
+
+
+def test_every_registered_schema_path_exists():
+    for entry in glimps_profile()["receipt_types"].values():
+        assert (ROOT / entry["schema_path"]).exists()
+
+
+def test_every_registered_example_path_exists():
+    for entry in glimps_profile()["receipt_types"].values():
+        assert (ROOT / entry["example_path"]).exists()
+
+
+def test_every_registered_validator_path_exists():
+    for entry in glimps_profile()["receipt_types"].values():
+        assert (ROOT / entry["validator"]).exists()
+
+
+def test_glimps_has_exact_registered_receipt_types():
+    assert set(glimps_profile()["receipt_types"]) == EXPECTED_GLIMPS_RECEIPT_TYPES
+    assert registered_glimps_receipt_types(ROOT) == EXPECTED_GLIMPS_RECEIPT_TYPES
+
+
+def test_every_registered_glimps_example_validates_through_assay_dispatcher():
+    for receipt_type, entry in glimps_profile()["receipt_types"].items():
+        result, report = run_json_command("scripts/assay_validate.py", entry["example_path"], "--json")
+        assert result.returncode == 0
+        assert report["ok"] is True
+        assert report["receipt_type"] == receipt_type
+        assert report["profile"] == "glimps"
+        assert report["errors"] == []
+
+
+def test_every_registered_glimps_example_validates_through_profile_validator():
+    for receipt_type, entry in glimps_profile()["receipt_types"].items():
+        result, report = run_json_command("scripts/glimps_validate.py", entry["example_path"], "--json")
+        assert result.returncode == 0
+        assert report["passed"] is True
+        assert report["results"][0]["receipt_type"] == receipt_type
+        assert report["results"][0]["errors"] == []
+
+
+def test_no_glimps_entry_is_normative_crs_profile():
+    profile = glimps_profile()
+    assert profile["normative_crs_profile"] is False
+    for entry in profile["receipt_types"].values():
+        assert entry["normative_crs_profile"] is False
+
+
+def test_normative_profiles_require_promotion_artifact():
+    for profile_name, profile in registry()["profiles"].items():
+        if profile.get("normative_crs_profile") is True:
+            promotion_document = profile.get("promotion_document")
+            assert promotion_document, f"{profile_name} lacks promotion_document"
+            assert (ROOT / promotion_document).exists()
+
+
+def test_no_incubating_profile_can_claim_runtime_authority():
+    for profile_name, profile in registry()["profiles"].items():
+        if profile.get("status") != "incubating":
+            continue
+        for receipt_type, entry in profile["receipt_types"].items():
+            boundary = entry["authority_boundary"]
+            assert boundary["can_govern_execution"] is False, (profile_name, receipt_type)
+            assert boundary["can_modify_policy"] is False, (profile_name, receipt_type)
+            assert boundary["can_allocate_execution_budget"] is False, (profile_name, receipt_type)
+            assert boundary["can_raise_confidence_without_receipts"] is False, (
+                profile_name,
+                receipt_type,
+            )
+
+
+def test_assay_validate_still_rejects_unknown_glimps_receipt_type():
+    report = dispatch_profile_validation([{"receipt_type": "glimps.unknown/v0"}])
+    assert report["ok"] is False
+    assert report["receipt_type"] == "glimps.unknown/v0"
+    assert report["profile"] == "glimps"
+    assert report["errors"] == ["unregistered GLIMPS receipt_type: 'glimps.unknown/v0'"]
+
+
+def test_assay_validate_output_shape_for_registered_glimps_receipts():
+    for entry in glimps_profile()["receipt_types"].values():
+        _, report = run_json_command("scripts/assay_validate.py", entry["example_path"], "--json")
+        assert set(report) == {"ok", "receipt_type", "profile", "errors"}


### PR DESCRIPTION
## Summary

- Adds `RCE_PROFILE.md`: normative profile defining Replay-Constrained Episodes as a companion to SPEC.md
- Adds `schemas/rce_episode_contract.schema.json`: JSON Schema for the Episode Contract
- Schema/docs only — no implementation code

## What this defines

An RCE is a verifiable work unit whose correctness is defined by replay against recorded evidence. Episodes compile into existing Assay Proof Packs.

**Identity model:** three identities (`episode_id`, `episode_spec_hash`, `pack_root_sha256`) with explicit replay-normative view separating descriptive from identity-bearing fields.

**ReplayScript v0:** 4 opcodes (`LOAD_INPUT`, `ASSERT_HASH`, `APPLY_TRANSFORM`, `EMIT_OUTPUT`) in a typed DAG.

**Receipt types:** 4 CRS-conformant types (`episode_open`, `episode_step`, `episode_close`, `replay_result`).

**Verdict semantics:** MATCH/DIVERGE/INTEGRITY_FAIL mapped to existing `receipt_integrity × claim_check` axes (exit 0/1/2).

**Deterministic verification:** 4 mandatory phases in fixed order. Two conforming verifiers produce the same verdict.

**Derived hash inventory:** Every hash field has a normative derivation rule or explicit local-attestation classification.

## Design lineage

5-pass tightening from `~/RCE_V0_NORMATIVE_SPEC.md`:
1. Initial draft (identity, receipts, verdicts, boundaries)
2. Replay-normative view, ULID deconfliction, version strata, Tier B collapse
3. Step status model, failure propagation, verification order, DIVERGE policy
4. Environment identity narrowing, missing-artifact classification
5. Derived hash inventory (Appendix C)

## Test plan

- [ ] JSON Schema validates against golden-path Episode Contract fixture
- [ ] Profile cross-referenced against CRS v0.1 receipt envelope fields
- [ ] All derived hash derivation rules checked for field-name consistency with schema
- [ ] No semantic expansion beyond normative spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)